### PR TITLE
[#66] 비밀번호 재설정 페이지 마크업

### DIFF
--- a/src/constants/path.ts
+++ b/src/constants/path.ts
@@ -11,6 +11,7 @@ export const PATH = {
   LOGIN: "/signin",
   MY_PAGE: "/my-page",
   REDIRECT: "/auth/:provider",
+  PASSWORD_RESET: "/password-reset",
   RELOAD: 0,
 } as const;
 // 참고

--- a/src/pages/passwordResetPage/PasswordReset.style.ts
+++ b/src/pages/passwordResetPage/PasswordReset.style.ts
@@ -41,6 +41,10 @@ export const PasswordResetInputWrapper = styled.div`
   gap: 8px;
 `;
 
+export const PasswordResetRelativeWrapper = styled.div`
+  position: relative;
+`;
+
 export const PasswordResetInputTitle = styled.p`
   ${({ theme }) => theme.typo.caption1}
   color: ${({ theme }) => theme.color.greyScale1};

--- a/src/pages/passwordResetPage/PasswordReset.style.ts
+++ b/src/pages/passwordResetPage/PasswordReset.style.ts
@@ -1,0 +1,95 @@
+import styled from "styled-components";
+
+export const PasswordResetContainer = styled.form`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  background-color: white;
+
+  margin: 32px 0 0 0;
+
+  padding-bottom: 100px;
+`;
+
+export const PasswordResetTitleContainer = styled.div`
+  display: flex;
+
+  width: calc(100% - 40px);
+`;
+
+export const PasswordResetTitle = styled.h1`
+  ${({ theme }) => theme.typo.title2}
+  color: ${({ theme }) => theme.color.greyScale1};
+`;
+
+export const PasswordResetInputContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+
+  margin: 80px 0 76px 0;
+
+  width: calc(100% - 40px);
+`;
+
+export const PasswordResetInputWrapper = styled.div`
+  width: 100%;
+
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+`;
+
+export const PasswordResetInputTitle = styled.p`
+  ${({ theme }) => theme.typo.caption1}
+  color: ${({ theme }) => theme.color.greyScale1};
+  font-weight: 400;
+`;
+
+export const PasswordResetInput = styled.input`
+  width: 100%;
+  height: 48px;
+
+  border: 1px solid ${({ theme }) => theme.color.greyScale5};
+  border-radius: 8px;
+
+  padding-left: 8px;
+
+  &::placeholder {
+    ${({ theme }) => theme.typo.caption1}
+    color: ${({ theme }) => theme.color.greyScale5};
+    font-weight: 300;
+  }
+`;
+
+export const PasswordResetInputBtn = styled.button`
+  ${({ theme }) => theme.typo.caption2}
+  position: absolute;
+
+  width: 72px;
+  height: 28px;
+
+  border: 1px solid ${({ theme }) => theme.color.percentOrange};
+  border-radius: 8px;
+
+  color: ${({ theme }) => theme.color.percentOrange};
+
+  top: 10px;
+  right: 10px;
+`;
+
+export const PasswordResetInputCaption = styled.span<{ $color: string }>`
+  ${({ theme }) => theme.typo.caption3}
+  color: ${({ $color }) => $color};
+`;
+
+export const PasswordResetSubmitBtn = styled.button`
+  width: calc(100% - 40px);
+  height: 48px;
+  border-radius: 8px;
+
+  color: white;
+
+  background-color: ${({ theme }) => theme.color.percentOrange};
+`;

--- a/src/pages/passwordResetPage/PasswordReset.tsx
+++ b/src/pages/passwordResetPage/PasswordReset.tsx
@@ -1,0 +1,61 @@
+import * as S from "./PasswordReset.style";
+
+const PasswordReset = () => {
+  return (
+    <S.PasswordResetContainer>
+      <S.PasswordResetTitleContainer>
+        <S.PasswordResetTitle>비밀번호 변경</S.PasswordResetTitle>
+      </S.PasswordResetTitleContainer>
+
+      <S.PasswordResetInputContainer>
+        <S.PasswordResetInputWrapper>
+          <S.PasswordResetInputTitle>이메일</S.PasswordResetInputTitle>
+          <div style={{ position: "relative" }}>
+            <S.PasswordResetInput placeholder="이메일을 입력해주세요" />
+            <S.PasswordResetInputBtn type="button">
+              인증 요청
+            </S.PasswordResetInputBtn>
+          </div>
+          <S.PasswordResetInputCaption $color="#FF4949">
+            이미 사용중인 이메일 입니다
+          </S.PasswordResetInputCaption>
+        </S.PasswordResetInputWrapper>
+        <S.PasswordResetInputWrapper>
+          <S.PasswordResetInputTitle>인증번호 입력</S.PasswordResetInputTitle>
+          <div style={{ position: "relative" }}>
+            <S.PasswordResetInput placeholder="코드 6자리를 입력해주세요" />
+            <S.PasswordResetInputBtn type="button">
+              확인
+            </S.PasswordResetInputBtn>
+          </div>
+          <S.PasswordResetInputCaption $color="#FF4949">
+            잘못된 인증번호 입니다
+          </S.PasswordResetInputCaption>
+          <S.PasswordResetInputCaption $color="#0072B1">
+            인증이 완료되었습니다
+          </S.PasswordResetInputCaption>
+        </S.PasswordResetInputWrapper>
+        <S.PasswordResetInputWrapper>
+          <S.PasswordResetInputTitle>새 비밀번호</S.PasswordResetInputTitle>
+          <S.PasswordResetInput placeholder="비밀번호를 설정해주세요" />
+          <S.PasswordResetInputCaption $color="#FF4949">
+            비밀번호 입력 오류입니다
+          </S.PasswordResetInputCaption>
+        </S.PasswordResetInputWrapper>
+        <S.PasswordResetInputWrapper>
+          <S.PasswordResetInputTitle>
+            새 비밀번호 확인
+          </S.PasswordResetInputTitle>
+          <S.PasswordResetInput placeholder="동일한 비밀번호를 입력해주세요" />
+          <S.PasswordResetInputCaption $color="#FF4949">
+            입력하신 비밀번호와 다릅니다
+          </S.PasswordResetInputCaption>
+        </S.PasswordResetInputWrapper>
+      </S.PasswordResetInputContainer>
+
+      <S.PasswordResetSubmitBtn>비밀번호 변경</S.PasswordResetSubmitBtn>
+    </S.PasswordResetContainer>
+  );
+};
+
+export default PasswordReset;

--- a/src/pages/passwordResetPage/PasswordReset.tsx
+++ b/src/pages/passwordResetPage/PasswordReset.tsx
@@ -10,24 +10,24 @@ const PasswordReset = () => {
       <S.PasswordResetInputContainer>
         <S.PasswordResetInputWrapper>
           <S.PasswordResetInputTitle>이메일</S.PasswordResetInputTitle>
-          <div style={{ position: "relative" }}>
+          <S.PasswordResetRelativeWrapper>
             <S.PasswordResetInput placeholder="이메일을 입력해주세요" />
             <S.PasswordResetInputBtn type="button">
               인증 요청
             </S.PasswordResetInputBtn>
-          </div>
+          </S.PasswordResetRelativeWrapper>
           <S.PasswordResetInputCaption $color="#FF4949">
             이미 사용중인 이메일 입니다
           </S.PasswordResetInputCaption>
         </S.PasswordResetInputWrapper>
         <S.PasswordResetInputWrapper>
           <S.PasswordResetInputTitle>인증번호 입력</S.PasswordResetInputTitle>
-          <div style={{ position: "relative" }}>
+          <S.PasswordResetRelativeWrapper>
             <S.PasswordResetInput placeholder="코드 6자리를 입력해주세요" />
             <S.PasswordResetInputBtn type="button">
               확인
             </S.PasswordResetInputBtn>
-          </div>
+          </S.PasswordResetRelativeWrapper>
           <S.PasswordResetInputCaption $color="#FF4949">
             잘못된 인증번호 입니다
           </S.PasswordResetInputCaption>

--- a/src/pages/signInPage/SignIn.tsx
+++ b/src/pages/signInPage/SignIn.tsx
@@ -19,8 +19,8 @@ const SignIn = () => {
       <S.SignInSubmitBtn type="button">로그인</S.SignInSubmitBtn>
 
       <S.SignInLinkWrapper>
-        <S.SignInLink to="https://naver.com">비밀번호 찾기</S.SignInLink>
-        <S.SignInLink to="https://naver.com">회원가입 하기</S.SignInLink>
+        <S.SignInLink to="/password-reset">비밀번호 찾기</S.SignInLink>
+        <S.SignInLink to="/signup">회원가입 하기</S.SignInLink>
       </S.SignInLinkWrapper>
     </S.SignInContainer>
   );

--- a/src/pages/signUpPage/SignUp.style.ts
+++ b/src/pages/signUpPage/SignUp.style.ts
@@ -37,6 +37,10 @@ export const SignUpInputWrapper = styled.div`
   gap: 8px;
 `;
 
+export const SignUpInputRelativeWrapper = styled.div`
+  position: relative;
+`;
+
 export const SignUpInputTitle = styled.p`
   ${({ theme }) => theme.typo.caption1}
   color: ${({ theme }) => theme.color.greyScale1};

--- a/src/pages/signUpPage/SignUp.style.ts
+++ b/src/pages/signUpPage/SignUp.style.ts
@@ -5,7 +5,11 @@ export const SignUpContainer = styled.form`
   flex-direction: column;
   align-items: center;
 
-  margin: 40px 20px 0 20px;
+  background-color: white;
+
+  margin: 40px 0 0 0;
+
+  padding-bottom: 100px;
 `;
 
 export const SignUpTitle = styled.p`
@@ -22,7 +26,7 @@ export const SignUpInputContainer = styled.div`
 
   margin: 0 0 40px 0;
 
-  width: 100%;
+  width: calc(100% - 40px);
 `;
 
 export const SignUpInputWrapper = styled.div`
@@ -62,10 +66,10 @@ export const SignUpInputBtn = styled.button`
   width: 72px;
   height: 28px;
 
-  border: 1px solid #f27c18;
+  border: 1px solid ${({ theme }) => theme.color.percentOrange};
   border-radius: 8px;
 
-  color: #f27c18;
+  color: ${({ theme }) => theme.color.percentOrange};
 
   top: 10px;
   right: 10px;
@@ -81,7 +85,7 @@ export const SignUpCheckBoxContainer = styled.div`
   flex-direction: column;
   gap: 10px;
 
-  width: 100%;
+  width: calc(100% - 40px);
 
   margin: 0 0 64px 0;
 `;
@@ -105,7 +109,7 @@ export const SignUpCheckBoxLink = styled.a`
 `;
 
 export const SignUpSubmitBtn = styled.button`
-  width: 100%;
+  width: calc(100% - 40px);
   height: 48px;
   border-radius: 8px;
 

--- a/src/pages/signUpPage/SignUp.tsx
+++ b/src/pages/signUpPage/SignUp.tsx
@@ -4,23 +4,24 @@ const SignUp = () => {
   return (
     <S.SignUpContainer>
       <S.SignUpTitle>회원가입</S.SignUpTitle>
+
       <S.SignUpInputContainer>
         <S.SignUpInputWrapper>
           <S.SignUpInputTitle>이메일</S.SignUpInputTitle>
-          <div style={{ position: "relative" }}>
+          <S.SignUpInputRelativeWrapper>
             <S.SignUpInput placeholder="이메일을 입력해주세요" />
             <S.SignUpInputBtn type="button">인증 요청</S.SignUpInputBtn>
-          </div>
+          </S.SignUpInputRelativeWrapper>
           <S.SignUpInputCaption $color="#FF4949">
             이미 사용중인 이메일 입니다
           </S.SignUpInputCaption>
         </S.SignUpInputWrapper>
         <S.SignUpInputWrapper>
           <S.SignUpInputTitle>인증번호 입력</S.SignUpInputTitle>
-          <div style={{ position: "relative" }}>
+          <S.SignUpInputRelativeWrapper>
             <S.SignUpInput placeholder="코드 6자리를 입력해주세요" />
             <S.SignUpInputBtn type="button">확인</S.SignUpInputBtn>
-          </div>
+          </S.SignUpInputRelativeWrapper>
           <S.SignUpInputCaption $color="#FF4949">
             잘못된 인증번호 입니다
           </S.SignUpInputCaption>

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -14,6 +14,7 @@ import TransferSale from "../pages/transferSalePage";
 import RoomDetail from "@pages/roomDetailPage/RoomDetail";
 import TransferPurchase from "../pages/transferPurchasePage";
 import TransferWritingPrice from "@/pages/transerWritingPricePage/TransferWritingPrice";
+import PasswordReset from "@/pages/passwordResetPage/PasswordReset";
 
 export const router = createBrowserRouter([
   {
@@ -65,6 +66,10 @@ export const router = createBrowserRouter([
             <RoomDetail />
           </Suspense>
         ),
+      },
+      {
+        path: PATH.PASSWORD_RESET,
+        element: <PasswordReset />,
       },
     ],
   },


### PR DESCRIPTION
### Issue Number

close #66

### ⛳️ Task

- [x] 화이팅하기
- [x] 비밀번호 재설정 페이지 마크업
- [x] 기타 스타일 수정사항 반영

### ✍️ Note

단순 비밀번호 재설정 페이지 마크업 입니다.

회원가입, 비밀번호 재설정 페이지가 길어지면 회색 화면이 침범하던 경우를 개선했습니다. (width: calc(100% - 40px))
추가로 기존 페이지에 globalStyle 및 피그마 업데이트 사항을 반영했습니다.

이후 바텀 네비게이션에 해당 페이지 제외 로직을 추가할 예정입니다.

### 📸 Screenshot

<img width="709" alt="스크린샷 2024-01-09 15 50 57" src="https://github.com/SCBJ-7/SCBJ-FE/assets/87873821/d376a87f-ccba-45d0-a41b-f6508d24cf43">

### 📎 Reference
