### PR TITLE
[#65] 로그인 페이지 기능 연결

### DIFF
--- a/src/components/toast/Toast.style.ts
+++ b/src/components/toast/Toast.style.ts
@@ -1,13 +1,14 @@
 import { motion } from "framer-motion";
 import styled from "styled-components";
 
-export const ToastContainer = styled(motion.div)`
+export const ToastContainer = styled(motion.div)<{ $isError: boolean }>`
   width: 360px;
   height: 40px;
   border-radius: 28px;
 
   ${({ theme }) => theme.typo.button7};
-  background-color: ${({ theme }) => theme.color.black};
+  background-color: ${({ $isError, theme }) =>
+    $isError ? "white" : theme.color.black};
   color: white;
   box-shadow: 2px 2px 8px 0 rgba(0, 0, 0, 0.2);
 
@@ -24,6 +25,6 @@ export const ToastContainer = styled(motion.div)`
   z-index: 100;
 
   & strong {
-    color: #ff3478;
+    color: ${({ $isError }) => ($isError ? "#FF4949" : "#ff3478")};
   }
 `;

--- a/src/components/toast/Toast.tsx
+++ b/src/components/toast/Toast.tsx
@@ -7,9 +7,10 @@ import { AnimatePresence } from "framer-motion";
 interface ToastProps {
   strings: (string | ReactNode)[];
   duration?: number;
+  isError?: boolean;
 }
 
-const Toast = ({ strings, duration = 5000 }: ToastProps) => {
+const Toast = ({ strings, duration = 5000, isError = false }: ToastProps) => {
   const [visible, setVisible] = useState(true);
 
   useEffect(() => {
@@ -48,6 +49,7 @@ const Toast = ({ strings, duration = 5000 }: ToastProps) => {
               initial="hidden"
               animate="visible"
               exit="hidden"
+              $isError={isError}
             >
               {strings.map((str, idx) => {
                 return typeof str === "string" ? (

--- a/src/pages/signInPage/SignIn.tsx
+++ b/src/pages/signInPage/SignIn.tsx
@@ -1,22 +1,100 @@
 import * as S from "./SignIn.style";
+import { useForm } from "react-hook-form";
+import axios from "axios";
+import { useNavigate } from "react-router-dom";
+import { useState } from "react";
+
+import Toast from "@/components/toast/Toast";
+
+type FormValues = {
+  email: string;
+  password: string;
+};
 
 const SignIn = () => {
+  const navigate = useNavigate();
+  const [isToastShow, setIsToastShow] = useState(false);
+
+  const {
+    register,
+    formState: { errors },
+    handleSubmit,
+  } = useForm({
+    defaultValues: {
+      email: "",
+      password: "",
+    },
+  });
+
+  const handleOnSubmit = async (data: FormValues) => {
+    const { email, password } = data;
+    await axios
+      .post("https://3.34.147.187.nip.io/v1/members/signin", {
+        email,
+        password,
+      })
+      .then(
+        ({
+          data: {
+            data: {
+              memberResponse,
+              tokenResponse: { accessToken, refreshToken },
+            },
+          },
+        }) => {
+          // Todo : 임시로 localStorage에 사용자 정보, 토큰 둘 다 저장히지만 더 좋은 방법 찾기
+          localStorage.setItem("memberResponse", memberResponse);
+          localStorage.setItem("accessToken", accessToken);
+          localStorage.setItem("refreshToken", refreshToken);
+
+          navigate("/");
+        },
+      )
+      .catch(({ response }) => {
+        console.log(response);
+        setIsToastShow(true);
+        setTimeout(() => {
+          setIsToastShow(false);
+        }, 6000);
+      });
+  };
+
   return (
-    <S.SignInContainer>
+    <S.SignInContainer onSubmit={handleSubmit(handleOnSubmit)}>
+      {isToastShow ? (
+        <Toast isError strings={[<>아이디 혹은 비밀번호를 확인해주세요</>]} />
+      ) : null}
       <S.SignInLogo />
 
       <S.SignInInputContainer>
         <S.SignInInputWrapper>
           <S.SignInInputTitle>이메일</S.SignInInputTitle>
-          <S.SignInInput placeholder="이메일을 입력해주세요" />
+          <S.SignInInput
+            {...register("email", {
+              required: "이메일을 입력해주세요",
+            })}
+            placeholder="이메일을 입력해주세요"
+          />
+          <S.SignInInputCaption $color="#FF4949">
+            {errors.email?.message}
+          </S.SignInInputCaption>
         </S.SignInInputWrapper>
         <S.SignInInputWrapper>
           <S.SignInInputTitle>비밀번호</S.SignInInputTitle>
-          <S.SignInInput placeholder="비밀번호를 입력해주세요" />
+          <S.SignInInput
+            {...register("password", {
+              required: "비밀번호를 입력해주세요",
+            })}
+            placeholder="비밀번호를 입력해주세요"
+            type="password"
+          />
+          <S.SignInInputCaption $color="#FF4949">
+            {errors.password?.message}
+          </S.SignInInputCaption>
         </S.SignInInputWrapper>
       </S.SignInInputContainer>
 
-      <S.SignInSubmitBtn type="button">로그인</S.SignInSubmitBtn>
+      <S.SignInSubmitBtn type="submit">로그인</S.SignInSubmitBtn>
 
       <S.SignInLinkWrapper>
         <S.SignInLink to="/password-reset">비밀번호 찾기</S.SignInLink>


### PR DESCRIPTION
### Issue Number

close #65

### ⛳️ Task

- [x] 화이팅하기
- [x] 로그인 페이지 기능 연결
- [x] 유저 정보 및 토큰 임시로 localStorage에 저장
- [x] 에러용 Toast Prop 추가

### ✍️ Note

에러가 나왔을 때 잠시 에러 토스트가 뜨게 하기 위해서 isToastShow 라는 state를 사용했습니다.

로그인에 성공하면 localStroage에 reponse 데이터 저장 및 자동으로 메인페이지로 navigate 해도록 설정했습니다.

##사과문..##

제가 지금 코테준비때문에 정신이 없어서... 유저 상태와 토근 관리, API hook 처리등이 안되어있고 코드가 많이 지저분 합니다. 죄송합니다 ㅠㅠ

로그인 시 유저 정보 관리 및 토큰 관리는 나중에 리팩토링으로 개선해야 할 것 같습니다...
만약 상태관리등에 관심이 있으시면 개선 해주시면 감사하겠습니다...!

다시한번 코테 준비등으로 인해 결과가 미흡한점 사과드립니다..

### 📸 Screenshot

<img width="832" alt="스크린샷 2024-01-11 16 37 28" src="https://github.com/SCBJ-7/SCBJ-FE/assets/87873821/d8337efb-9801-4b9e-9c6f-ed4ae0844f4c">

### 📎 Reference
