### PR TITLE
[#80] 비밀번호 찾기 페이지 기능 연결

### DIFF
--- a/src/pages/passwordResetPage/PasswordReset.style.ts
+++ b/src/pages/passwordResetPage/PasswordReset.style.ts
@@ -67,7 +67,9 @@ export const PasswordResetInput = styled.input`
   }
 `;
 
-export const PasswordResetInputBtn = styled.button`
+export const PasswordResetInputBtn = styled.button<{
+  $isCodeCorrect?: boolean;
+}>`
   ${({ theme }) => theme.typo.caption2}
   position: absolute;
 
@@ -76,24 +78,30 @@ export const PasswordResetInputBtn = styled.button`
 
   border: 1px solid ${({ theme }) => theme.color.percentOrange};
   border-radius: 8px;
+  background-color: ${({ $isCodeCorrect, theme }) =>
+    $isCodeCorrect ? theme.color.percentOrange : "white"};
 
-  color: ${({ theme }) => theme.color.percentOrange};
+  color: ${({ $isCodeCorrect, theme }) =>
+    $isCodeCorrect ? "white" : theme.color.percentOrange};
 
   top: 10px;
   right: 10px;
 `;
 
-export const PasswordResetInputCaption = styled.span<{ $color: string }>`
+export const PasswordResetInputCaption = styled.span<{
+  $isCodeCorrect?: boolean;
+}>`
   ${({ theme }) => theme.typo.caption3}
-  color: ${({ $color }) => $color};
+  color: ${({ $isCodeCorrect }) => ($isCodeCorrect ? "#0072B1" : "#FF4949")};
 `;
 
-export const PasswordResetSubmitBtn = styled.button`
+export const PasswordResetSubmitBtn = styled.button<{ $isValid: boolean }>`
   width: calc(100% - 40px);
   height: 48px;
   border-radius: 8px;
 
   color: white;
 
-  background-color: ${({ theme }) => theme.color.percentOrange};
+  background-color: ${({ $isValid, theme }) =>
+    $isValid ? theme.color.percentOrange : theme.color.greyScale5};
 `;

--- a/src/pages/passwordResetPage/PasswordReset.style.ts
+++ b/src/pages/passwordResetPage/PasswordReset.style.ts
@@ -65,6 +65,12 @@ export const PasswordResetInput = styled.input`
     color: ${({ theme }) => theme.color.greyScale5};
     font-weight: 300;
   }
+
+  &::-webkit-inner-spin-button,
+  &::-webkit-outer-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+  }
 `;
 
 export const PasswordResetInputBtn = styled.button<{

--- a/src/pages/passwordResetPage/PasswordReset.tsx
+++ b/src/pages/passwordResetPage/PasswordReset.tsx
@@ -39,7 +39,7 @@ const PasswordReset = () => {
   const handleOnSubmit = async (data: FormValues) => {
     const { password, email } = data;
     await axios
-      .post("https://3.34.147.187.nip.io/v1/members/password", {
+      .patch("https://3.34.147.187.nip.io/v1/members/password", {
         email,
         password,
       })

--- a/src/pages/passwordResetPage/PasswordReset.tsx
+++ b/src/pages/passwordResetPage/PasswordReset.tsx
@@ -1,8 +1,87 @@
+import { useForm } from "react-hook-form";
 import * as S from "./PasswordReset.style";
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import axios from "axios";
+
+type FormValues = {
+  email: string;
+  password: string;
+  checkPassword: string;
+  code: string;
+  isCodeCorrect: boolean;
+};
 
 const PasswordReset = () => {
+  const navigate = useNavigate();
+
+  const {
+    register,
+    getValues,
+    setValue,
+    formState: { errors, isValid },
+    handleSubmit,
+    setError,
+    clearErrors,
+  } = useForm({
+    defaultValues: {
+      email: "",
+      code: "",
+      password: "",
+      checkPassword: "",
+      isCodeCorrect: false,
+    },
+  });
+
+  const [isEmailValidated, setIsEmailValidated] = useState(false);
+  const [codeState, setCodeState] = useState("######");
+
+  const handleOnSubmit = async (data: FormValues) => {
+    const { password } = data;
+    await axios
+      .post("https://3.34.147.187.nip.io/v1/members/password", {
+        password,
+      })
+      .then(() => {
+        navigate("/signin");
+      })
+      .catch(({ response }) => {
+        console.log(response);
+        alert(response.data.message);
+      });
+  };
+
+  const handleEmailValidateClick = async () => {
+    await axios
+      .post("https://3.34.147.187.nip.io/v1/members/email", {
+        email: getValues("email"),
+      })
+      .then((response) => {
+        if (response.status === 200) {
+          clearErrors("email");
+          setCodeState(response.data.data);
+          setIsEmailValidated(true);
+        }
+      })
+      .catch(({ response }) => {
+        setError("email", { message: response.data.message });
+        setIsEmailValidated(false);
+      });
+  };
+
+  const handleValidationCodeClick = () => {
+    const code = getValues("code");
+    if (code === codeState) {
+      setValue("isCodeCorrect", true);
+      clearErrors("isCodeCorrect");
+    } else {
+      setValue("isCodeCorrect", false);
+      setError("isCodeCorrect", { message: "잘못된 인증번호입니다" });
+    }
+  };
+
   return (
-    <S.PasswordResetContainer>
+    <S.PasswordResetContainer onSubmit={handleSubmit(handleOnSubmit)}>
       <S.PasswordResetTitleContainer>
         <S.PasswordResetTitle>비밀번호 변경</S.PasswordResetTitle>
       </S.PasswordResetTitleContainer>
@@ -11,49 +90,110 @@ const PasswordReset = () => {
         <S.PasswordResetInputWrapper>
           <S.PasswordResetInputTitle>이메일</S.PasswordResetInputTitle>
           <S.PasswordResetRelativeWrapper>
-            <S.PasswordResetInput placeholder="이메일을 입력해주세요" />
-            <S.PasswordResetInputBtn type="button">
-              인증 요청
+            <S.PasswordResetInput
+              {...register("email", {
+                required: "이메일을 입력해주세요",
+                pattern: {
+                  value:
+                    /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/,
+                  message: "이메일 양식이 올바르지 않습니다",
+                },
+              })}
+              placeholder="이메일을 입력해주세요"
+            />
+            <S.PasswordResetInputBtn
+              type="button"
+              $isCodeCorrect={isEmailValidated}
+              onClick={handleEmailValidateClick}
+            >
+              {isEmailValidated ? "재요청" : "인증 요청"}{" "}
             </S.PasswordResetInputBtn>
           </S.PasswordResetRelativeWrapper>
-          <S.PasswordResetInputCaption $color="#FF4949">
-            이미 사용중인 이메일 입니다
+          <S.PasswordResetInputCaption>
+            {errors.email?.message}{" "}
           </S.PasswordResetInputCaption>
         </S.PasswordResetInputWrapper>
+
         <S.PasswordResetInputWrapper>
           <S.PasswordResetInputTitle>인증번호 입력</S.PasswordResetInputTitle>
           <S.PasswordResetRelativeWrapper>
-            <S.PasswordResetInput placeholder="코드 6자리를 입력해주세요" />
-            <S.PasswordResetInputBtn type="button">
-              확인
+            <S.PasswordResetInput
+              {...register("code")}
+              type="number"
+              maxLength={6}
+              placeholder="코드 6자리를 입력해주세요"
+            />
+            <input
+              style={{ display: "none" }}
+              type="checkbox"
+              {...register("isCodeCorrect", {
+                required: true,
+                validate: (isCodeCorrect) => {
+                  return isCodeCorrect === true || "잘못된 인증번호입니다";
+                },
+              })}
+            />
+            <S.PasswordResetInputBtn
+              $isCodeCorrect={getValues("isCodeCorrect")}
+              onClick={handleValidationCodeClick}
+              type="button"
+            >
+              {getValues("isCodeCorrect") ? "인증확인" : "확인"}{" "}
             </S.PasswordResetInputBtn>
           </S.PasswordResetRelativeWrapper>
-          <S.PasswordResetInputCaption $color="#FF4949">
-            잘못된 인증번호 입니다
-          </S.PasswordResetInputCaption>
-          <S.PasswordResetInputCaption $color="#0072B1">
-            인증이 완료되었습니다
+          <S.PasswordResetInputCaption
+            $isCodeCorrect={getValues("isCodeCorrect")}
+          >
+            {getValues("isCodeCorrect") ? "인증이 완료되었습니다" : ""}
+            {errors.isCodeCorrect?.message}{" "}
           </S.PasswordResetInputCaption>
         </S.PasswordResetInputWrapper>
+
         <S.PasswordResetInputWrapper>
           <S.PasswordResetInputTitle>새 비밀번호</S.PasswordResetInputTitle>
-          <S.PasswordResetInput placeholder="비밀번호를 설정해주세요" />
-          <S.PasswordResetInputCaption $color="#FF4949">
-            비밀번호 입력 오류입니다
+          <S.PasswordResetInput
+            {...register("password", {
+              required: "비빌번호를 설정해주세요.",
+              pattern: {
+                value: /^(?=.*[a-zA-Z])(?=.*[!@#$%^*+=-])(?=.*[0-9]).{7,}$/,
+                message:
+                  "영문, 숫자, 특수기호중 2개 이상을 포함해 8자 이상이여야 합니다.",
+              },
+            })}
+            type="password"
+            placeholder="비밀번호를 설정해주세요"
+          />
+          <S.PasswordResetInputCaption>
+            {errors.password?.message}
           </S.PasswordResetInputCaption>
         </S.PasswordResetInputWrapper>
+
         <S.PasswordResetInputWrapper>
           <S.PasswordResetInputTitle>
             새 비밀번호 확인
           </S.PasswordResetInputTitle>
-          <S.PasswordResetInput placeholder="동일한 비밀번호를 입력해주세요" />
-          <S.PasswordResetInputCaption $color="#FF4949">
-            입력하신 비밀번호와 다릅니다
+          <S.PasswordResetInput
+            {...register("checkPassword", {
+              required: "입력하신 비밀번호와 다릅니다.",
+              validate: (checkPassword) => {
+                return (
+                  getValues("password") === checkPassword ||
+                  "입력하신 비밀번호와 다릅니다."
+                );
+              },
+            })}
+            type="password"
+            placeholder="동일한 비밀번호를 입력해주세요"
+          />
+          <S.PasswordResetInputCaption>
+            {errors.checkPassword?.message}
           </S.PasswordResetInputCaption>
         </S.PasswordResetInputWrapper>
       </S.PasswordResetInputContainer>
 
-      <S.PasswordResetSubmitBtn>비밀번호 변경</S.PasswordResetSubmitBtn>
+      <S.PasswordResetSubmitBtn $isValid={isValid} type="submit">
+        비밀번호 변경
+      </S.PasswordResetSubmitBtn>
     </S.PasswordResetContainer>
   );
 };

--- a/src/pages/passwordResetPage/PasswordReset.tsx
+++ b/src/pages/passwordResetPage/PasswordReset.tsx
@@ -37,9 +37,10 @@ const PasswordReset = () => {
   const [codeState, setCodeState] = useState("######");
 
   const handleOnSubmit = async (data: FormValues) => {
-    const { password } = data;
+    const { password, email } = data;
     await axios
       .post("https://3.34.147.187.nip.io/v1/members/password", {
+        email,
         password,
       })
       .then(() => {

--- a/src/pages/signUpPage/SignUp.style.ts
+++ b/src/pages/signUpPage/SignUp.style.ts
@@ -61,6 +61,12 @@ export const SignUpInput = styled.input`
     color: ${({ theme }) => theme.color.greyScale5};
     font-weight: 300;
   }
+
+  &::-webkit-inner-spin-button,
+  &::-webkit-outer-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+  }
 `;
 
 export const SignUpInputBtn = styled.button<{ $isCodeCorrect?: boolean }>`


### PR DESCRIPTION
### Issue Number

close #80 

### ⛳️ Task

- [x] 화이팅하기
- [x] 비밀번호 찾기 페이지 react-hook-form 연동
- [x] 비밀번호 찾기 API 연결

### ✍️ Note
- 회원가입 페이지와 매우 유사한 로직입니다.

- 아직 백엔드 API가 수정이 안되어서 Header를 요구하고 있기 때문에 비밀번호 요청시 405가 반환됩니다.
(undefined)
--> 해결되었습니다! 이제 비밀번호 변경 가능합니다.

- 비밀번호 변경이 성공한 경우 자동으로 로그인 페이지로 navigate 해 두었습니다.

- 이 페이지는 토스트가 되어있지 않고 비밀번호 변경 실패시 alert으로 해두었습니다.
- 바텀 네비게이션이 안뜨도록 로직 수정이 필요합니다.

다시 한번 코테 준비로 인해 양질의 PR을 올리지 못하고 기능을 마무리하는것에 그친 점 사과드립니다...

### 📸 Screenshot

<img width="725" alt="스크린샷 2024-01-11 18 07 57" src="https://github.com/SCBJ-7/SCBJ-FE/assets/87873821/514564a0-36cd-4fbd-8f31-e760a82be9b4">

### 📎 Reference
