### PR TITLE
[#85] 토스트 전역으로 관리, zustand-persist 사용, 예외 조건 처리

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,12 @@
-import { Outlet } from "react-router-dom";
+import { Outlet, useLocation } from "react-router-dom";
 import Layout from "./components/layout/Layout.tsx";
+import Toast from "./components/toast/Toast.tsx";
 
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { fetchUserInfo } from "@apis/fetchUserInfo.ts";
-import { useUserInfoStore } from "./store/store.ts";
+import { useToastStore, useUserInfoStore } from "./store/store.ts";
+import { AnimatePresence } from "framer-motion";
+import { useEffect } from "react";
 
 function App() {
   const { data } = useSuspenseQuery({
@@ -21,8 +24,21 @@ function App() {
     });
   }
 
+  const toastConfig = useToastStore((state) => state.config);
+  const setToastConfig = useToastStore((state) => state.setToastConfig);
+  const location = useLocation();
+
+  useEffect(() => {
+    setToastConfig({
+      isShow: false,
+      strings: toastConfig.strings,
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [location.pathname]);
+
   return (
     <Layout>
+      <AnimatePresence>{toastConfig.isShow && <Toast />}</AnimatePresence>
       <Outlet />
     </Layout>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,6 +31,7 @@ function App() {
   useEffect(() => {
     setToastConfig({
       isShow: false,
+      isError: false,
       strings: toastConfig.strings,
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/apis/fetchUserInfo.ts
+++ b/src/apis/fetchUserInfo.ts
@@ -7,6 +7,6 @@ export const fetchUserInfo = async (): Promise<IUserInfo | undefined> => {
     const response = await axios.get("/v1/members");
     return response.data.data as IUserInfo;
   } catch (err) {
-    alert("⚠️예기치 못한 에러가 발생하였습니다.");
+    alert(`⚠️예기치 못한 에러가 발생하였습니다.: ${err}`);
   }
 };

--- a/src/components/toast/Toast.tsx
+++ b/src/components/toast/Toast.tsx
@@ -1,22 +1,9 @@
-import { ReactNode, useEffect, useState } from "react";
-import { createPortal } from "react-dom";
 import * as S from "./Toast.style";
+import { useToastStore } from "@/store/store";
 
-import { AnimatePresence } from "framer-motion";
-
-interface ToastProps {
-  strings: (string | ReactNode)[];
-  duration?: number;
-}
-
-const Toast = ({ strings, duration = 5000 }: ToastProps) => {
-  const [visible, setVisible] = useState(true);
-
-  useEffect(() => {
-    setTimeout(() => {
-      setVisible(false);
-    }, duration);
-  }, [duration]);
+const Toast = () => {
+  const ToastConfig = useToastStore((state) => state.config);
+  const { strings } = ToastConfig;
 
   const variants = {
     visible: {
@@ -26,7 +13,7 @@ const Toast = ({ strings, duration = 5000 }: ToastProps) => {
         duration: 0.3,
         type: "spring",
         stiffness: 60,
-        delay: 0.6,
+        delay: 0.5,
       },
     },
     hidden: {
@@ -39,29 +26,20 @@ const Toast = ({ strings, duration = 5000 }: ToastProps) => {
   };
 
   return (
-    <>
-      {createPortal(
-        <AnimatePresence>
-          {visible && (
-            <S.ToastContainer
-              variants={variants}
-              initial="hidden"
-              animate="visible"
-              exit="hidden"
-            >
-              {strings.map((str, idx) => {
-                return typeof str === "string" ? (
-                  <span key={idx}>{str}</span>
-                ) : (
-                  <strong key={idx}>{str}</strong>
-                );
-              })}
-            </S.ToastContainer>
-          )}
-        </AnimatePresence>,
-        document.getElementById("overlay-root") as HTMLElement,
-      )}
-    </>
+    <S.ToastContainer
+      variants={variants}
+      initial="hidden"
+      animate="visible"
+      exit="hidden"
+    >
+      {strings.map((str, idx) => {
+        return typeof str === "string" ? (
+          <span key={idx}>{str}</span>
+        ) : (
+          <strong key={idx}>{str}</strong>
+        );
+      })}
+    </S.ToastContainer>
   );
 };
 

--- a/src/components/toast/Toast.tsx
+++ b/src/components/toast/Toast.tsx
@@ -26,29 +26,21 @@ const Toast = () => {
   };
 
   return (
-    <>
-      {createPortal(
-        <AnimatePresence>
-          {visible && (
-            <S.ToastContainer
-              variants={variants}
-              initial="hidden"
-              animate="visible"
-              exit="hidden"
-            >
-              {strings.map((str, idx) => {
-                return typeof str === "string" ? (
-                  <span key={idx}>{str}</span>
-                ) : (
-                  <strong key={idx}>{str}</strong>
-                );
-              })}
-            </S.ToastContainer>
-          )}
-        </AnimatePresence>,
-        document.getElementById("overlay-root") as HTMLElement,
-      )}
-    </>
+    <S.ToastContainer
+      variants={variants}
+      initial="hidden"
+      animate="visible"
+      exit="hidden"
+      $isError={ToastConfig.isError}
+    >
+      {strings.map((str, idx) => {
+        return typeof str === "string" ? (
+          <span key={idx}>{str}</span>
+        ) : (
+          <strong key={idx}>{str}</strong>
+        );
+      })}
+    </S.ToastContainer>
   );
 };
 

--- a/src/hooks/usePreventLeave.ts
+++ b/src/hooks/usePreventLeave.ts
@@ -1,0 +1,31 @@
+import { useEffect } from "react";
+
+const usePreventLeave = (global = false) => {
+  const handleBeforeUnload = (event: Event) => {
+    event.preventDefault();
+    event.returnValue = false; // Chrome requires returnValue to be set.
+  };
+  const onPreventLeave = () => {
+    window.addEventListener("beforeunload", handleBeforeUnload);
+  };
+  const offPreventLeave = () => {
+    window.removeEventListener("beforeunload", handleBeforeUnload);
+  };
+
+  // 만약 페이지 전체에 적용할 경우 global을 true로 입력해 window에 적용하면 된다.
+  // 단일 요소(e.g., HTMLInputElement)에 별개로 적용할 경우 on/off PreventLeave 이벤트를 사용한다.
+  useEffect(() => {
+    if (!global) return;
+    window.addEventListener("beforeunload", handleBeforeUnload);
+    return () => {
+      window.removeEventListener("beforeunload", handleBeforeUnload);
+    };
+  }, [global]);
+
+  return {
+    onPreventLeave,
+    offPreventLeave,
+  };
+};
+
+export default usePreventLeave;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -19,7 +19,7 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
     <QueryClientProvider client={queryClient}>
       <ThemeProvider theme={theme}>
         <GlobalStyle />
-        <Suspense fallback={<div>Global Loading...</div>}>
+        <Suspense fallback={<div>{/* Global Loading... */}</div>}>
           <RouterProvider router={router} />
         </Suspense>
       </ThemeProvider>

--- a/src/pages/signInPage/SignIn.tsx
+++ b/src/pages/signInPage/SignIn.tsx
@@ -2,9 +2,7 @@ import * as S from "./SignIn.style";
 import { useForm } from "react-hook-form";
 import axios from "axios";
 import { useNavigate } from "react-router-dom";
-import { useState } from "react";
-
-import Toast from "@/components/toast/Toast";
+import { useToastStore } from "@/store/store";
 
 type FormValues = {
   email: string;
@@ -13,7 +11,7 @@ type FormValues = {
 
 const SignIn = () => {
   const navigate = useNavigate();
-  const [isToastShow, setIsToastShow] = useState(false);
+  const setToastConfig = useToastStore((state) => state.setToastConfig);
 
   const {
     register,
@@ -52,18 +50,23 @@ const SignIn = () => {
       )
       .catch(({ response }) => {
         console.log(response);
-        setIsToastShow(true);
+        setToastConfig({
+          isShow: true,
+          isError: false,
+          strings: [[<>아이디 혹은 비밀번호를 확인해주세요</>]],
+        });
         setTimeout(() => {
-          setIsToastShow(false);
+          setToastConfig({
+            isShow: false,
+            isError: false,
+            strings: [[<>아이디 혹은 비밀번호를 확인해주세요</>]],
+          });
         }, 6000);
       });
   };
 
   return (
     <S.SignInContainer onSubmit={handleSubmit(handleOnSubmit)}>
-      {isToastShow ? (
-        <Toast isError strings={[<>아이디 혹은 비밀번호를 확인해주세요</>]} />
-      ) : null}
       <S.SignInLogo />
 
       <S.SignInInputContainer>

--- a/src/pages/transferWritingPage/TransferWriting.tsx
+++ b/src/pages/transferWritingPage/TransferWriting.tsx
@@ -1,10 +1,11 @@
 import * as S from "./TransferWriting.style";
 import TransferItem from "./transferItem/TransferItem";
-import Toast from "@/components/toast/Toast";
 
 import { fetchTransferItems } from "@/apis/fetchTransferItems";
+import { useToastStore } from "@/store/store";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { AnimatePresence } from "framer-motion";
+import { useEffect } from "react";
 
 const TransferWriting = () => {
   const UID = "DUMMY_UID";
@@ -15,9 +16,23 @@ const TransferWriting = () => {
     staleTime: 500000,
   });
 
+  const setToastConfig = useToastStore((state) => state.setToastConfig);
+
+  useEffect(() => {
+    setToastConfig({
+      isShow: true,
+      strings: [<>야놀자</>, "에서 예약하신 상품만 판매 가능해요."],
+    });
+    setTimeout(() => {
+      setToastConfig({
+        isShow: false,
+        strings: [<>야놀자</>, "에서 예약하신 상품만 판매 가능해요."],
+      });
+    }, 3000);
+  }, [setToastConfig]);
+
   return (
     <>
-      <Toast strings={[<>야놀자</>, "에서 예약하신 상품만 판매가 가능해요"]} />
       <S.Subtitle>판매할 내역을 선택해주세요.</S.Subtitle>
 
       <S.TransferItemList>

--- a/src/pages/transferWritingPage/TransferWriting.tsx
+++ b/src/pages/transferWritingPage/TransferWriting.tsx
@@ -21,11 +21,13 @@ const TransferWriting = () => {
   useEffect(() => {
     setToastConfig({
       isShow: true,
+      isError: false,
       strings: [<>야놀자</>, "에서 예약하신 상품만 판매 가능해요."],
     });
     setTimeout(() => {
       setToastConfig({
         isShow: false,
+        isError: false,
         strings: [<>야놀자</>, "에서 예약하신 상품만 판매 가능해요."],
       });
     }, 3000);

--- a/src/pages/transferWritingPricePage/TransferWritingPrice.tsx
+++ b/src/pages/transferWritingPricePage/TransferWritingPrice.tsx
@@ -7,10 +7,11 @@ import PaymentSection from "./paymentSection/PaymentSection";
 import AccountSection from "./accountSection/AccountSection";
 import AgreementSection from "./agreementSection/AgreementSection";
 import { useSelectedItemStore } from "@/store/store";
-import { formatDate } from "@/utils/dateFormater";
+import usePreventLeave from "@/hooks/usePreventLeave";
 
 const TransferWritingPrice = () => {
   const selectedItem = useSelectedItemStore((state) => state.selectedItem);
+  usePreventLeave(true);
 
   // first price value
   const [firstPrice, setFirstPrice] = useState("");
@@ -19,9 +20,6 @@ const TransferWritingPrice = () => {
   // second price value
   const [secondPrice, setSecondPrice] = useState("");
   const [downTimeAfter, setDownTimeAfter] = useState("");
-
-  // accountNumber (전역으로 바꾸자)
-  // const [accountNumber, setAccountNumber] = useState("");
 
   // Terms in second price Values
   const [opt1, setOpt1] = useState(false);
@@ -63,8 +61,6 @@ const TransferWritingPrice = () => {
     console.log("제출 수행");
   };
 
-  console.log(formatDate(new Date().toString()));
-
   return (
     <S.Container layout>
       <FirstPriceTag
@@ -87,6 +83,7 @@ const TransferWritingPrice = () => {
             onSecondPriceChange={setSecondPrice}
             downTimeAfter={downTimeAfter}
             onDownTimeAfterChange={setDownTimeAfter}
+            remainingDays={selectedItem.remainingDays}
             remainingTimes={selectedItem.remainingTimes}
             startDate={selectedItem.startDate}
             endDate={selectedItem.endDate}

--- a/src/pages/transferWritingPricePage/checkBox/CheckBoxSection.style.ts
+++ b/src/pages/transferWritingPricePage/checkBox/CheckBoxSection.style.ts
@@ -15,11 +15,14 @@ export const CheckContainer = styled.section`
   }
 `;
 
-export const CheckBox = styled.input.attrs({ type: "checkbox" })`
+export const CheckBox = styled.input.attrs({ type: "checkbox" })<{
+  $type: string;
+}>`
   width: 14px;
   height: 14px;
   border-radius: 1px;
-  accent-color: ${({ theme }) => theme.color.greyScale1};
+  accent-color: ${({ theme, $type }) =>
+    $type === "trigger" ? theme.color.percentBlue : theme.color.greyScale1};
 `;
 
 export const Label = styled.label<{

--- a/src/pages/transferWritingPricePage/checkBox/CheckBoxSection.tsx
+++ b/src/pages/transferWritingPricePage/checkBox/CheckBoxSection.tsx
@@ -8,6 +8,7 @@ interface CheckProps {
   firstPrice?: string;
   isChecked: boolean;
   onChecked: React.Dispatch<React.SetStateAction<boolean>>;
+  checkToFocus?: React.MutableRefObject<null>;
   onAllChecked?: [
     React.Dispatch<React.SetStateAction<boolean>>,
     React.Dispatch<React.SetStateAction<boolean>>,
@@ -30,6 +31,7 @@ const CheckBoxSection = ({
   firstPrice,
   isChecked,
   onChecked,
+  checkToFocus,
   onAllChecked,
   onAllRef,
   fontSize,
@@ -46,6 +48,11 @@ const CheckBoxSection = ({
     if (type === "trigger" && !firstPrice) {
       // 첫 가격이 입력 안 되어있으면 2차 가격 설정 체크 불가
       e.target.checked = false;
+      // 1차 가격 인풋에 포커스
+      if (checkToFocus?.current) {
+        console.log("here?");
+        (checkToFocus.current as HTMLInputElement).focus();
+      }
       return;
     }
 
@@ -102,7 +109,7 @@ const CheckBoxSection = ({
 
   return (
     <S.CheckContainer>
-      <S.CheckBox id={id} onChange={checkHandler} ref={checkRef} />
+      <S.CheckBox id={id} onChange={checkHandler} ref={checkRef} $type={type} />
       <S.Label
         htmlFor={id}
         $isChecked={isChecked}

--- a/src/pages/transferWritingPricePage/firstPriceTag/FirstPriceTag.tsx
+++ b/src/pages/transferWritingPricePage/firstPriceTag/FirstPriceTag.tsx
@@ -20,6 +20,7 @@ const FirstPriceTag = ({
   on2ndChecked,
 }: PriceTagProps) => {
   const checkRef = useRef(null);
+  const inputRef = useRef(null);
 
   useEffect(() => {
     // 1차 가격의 길이가 0이 되면 2차 가격 설정 체크 해제
@@ -47,6 +48,7 @@ const FirstPriceTag = ({
               maxPrice={purchasePrice}
               placeHolder="지정 가격"
               inputPosition="left"
+              inputRef={inputRef}
               inputData={inputData}
               text={["원"]}
               onDataChange={onFirstPriceChange}
@@ -54,6 +56,7 @@ const FirstPriceTag = ({
           </section>
         </S.Contents>
         <CheckBoxSection
+          checkToFocus={inputRef}
           checkRef={checkRef}
           firstPrice={inputData}
           id="first"

--- a/src/pages/transferWritingPricePage/inputSection/InputSection.tsx
+++ b/src/pages/transferWritingPricePage/inputSection/InputSection.tsx
@@ -1,43 +1,69 @@
+import priceFormat from "@/utils/priceFormat";
 import * as S from "./InputSection.style";
 
 interface InputProps {
+  inputPosition: "left" | "center" | "right";
+  inputRef?: React.MutableRefObject<null>;
   inputData: string;
   onDataChange: React.Dispatch<React.SetStateAction<string>>;
-  inputPosition: "left" | "center" | "right";
   text: [string, string] | [string];
   placeHolder: string;
   maxPrice?: number;
   remainingTimes?: number;
+  type?: "time" | "price";
 }
 
 const InputSection = ({
   inputPosition,
+  inputRef,
   text,
   onDataChange,
   placeHolder,
   inputData,
   maxPrice,
   remainingTimes,
+  type = "price",
 }: InputProps) => {
-  const inputHandler = (e: React.ChangeEvent) => {
+  const inputDataHandler = (e: React.ChangeEvent) => {
     const target = e.target as HTMLInputElement;
+    // 쉼표 제거
+    const temp = target.value.split(",").join("");
+    console.log(temp, "temp");
 
     // 입력값이 숫자가 아니면 입력 불가
-    if (isNaN(Number(target.value))) return;
+    if (isNaN(Number(temp))) return;
 
     // 구매가 데이터가 있다면 구매가 이상으로 못 올리게 설정
-    if (maxPrice && Number(target.value) > maxPrice) {
-      onDataChange(maxPrice.toString());
+    if (maxPrice && Number(temp) > maxPrice) {
+      onDataChange(priceFormat(maxPrice));
       return;
     }
 
     // 남은 시간 데이터가 있다면 남은 시간보다 이전 시간을 설정 못하게 설정
-    if (remainingTimes && Number(target.value) > remainingTimes) {
+    if (remainingTimes && Number(temp) > remainingTimes) {
       onDataChange((remainingTimes - 1).toString());
       return;
     }
 
-    onDataChange(target.value);
+    onDataChange(priceFormat(temp));
+  };
+
+  const inputBlurHandler = (e: React.FocusEvent) => {
+    if (type === "time") return;
+    const inputEl = e.target as HTMLInputElement;
+    const temp = inputEl.value.split(",").join("");
+    const beforeTwoDigits = temp.slice(0, temp.length - 2);
+    const lastTwoDigits = temp.slice(-2);
+
+    if (Number(temp) < 100) {
+      onDataChange("");
+      return;
+    }
+
+    if (lastTwoDigits !== "00") {
+      onDataChange(priceFormat(beforeTwoDigits + "00"));
+      return;
+    }
   };
 
   return (
@@ -45,8 +71,10 @@ const InputSection = ({
       {inputPosition === "right" && <p>{text[0]}</p>}
       {inputPosition === "center" && <p>{text[0]}</p>}
       <S.Input
+        ref={inputRef}
         placeholder={placeHolder}
-        onChange={inputHandler}
+        onChange={inputDataHandler}
+        onBlur={inputBlurHandler}
         value={inputData}
       />
       {inputPosition === "left" && <p>{text[0]}</p>}

--- a/src/pages/transferWritingPricePage/paymentSection/PaymentSection.tsx
+++ b/src/pages/transferWritingPricePage/paymentSection/PaymentSection.tsx
@@ -9,7 +9,7 @@ interface PaymentProps {
 }
 
 const PaymentSection = ({ price, is2ndChecked, title }: PaymentProps) => {
-  const FP = Number(price);
+  const FP = Number(price.split(",").join(""));
   let charge = 0;
   if (1000 < FP && FP <= 150000) {
     charge = Math.floor(FP * (2 / 100));
@@ -18,10 +18,6 @@ const PaymentSection = ({ price, is2ndChecked, title }: PaymentProps) => {
   } else if (300000 < FP) {
     charge = Math.floor(FP * (5 / 100));
   }
-
-  // const animate = {
-  //   opacity: [0, 1],
-  // };
 
   return (
     <S.Container $is2ndChecked={is2ndChecked}>

--- a/src/pages/transferWritingPricePage/secondPriceTag/SecondPriceTag.tsx
+++ b/src/pages/transferWritingPricePage/secondPriceTag/SecondPriceTag.tsx
@@ -4,6 +4,7 @@ import * as S from "./SecondPriceTag.style";
 
 import { format } from "date-fns";
 import { ko } from "date-fns/locale";
+import priceFormat from "@/utils/priceFormat";
 
 interface PriceTagProps {
   firstPrice: string;
@@ -11,6 +12,7 @@ interface PriceTagProps {
   onSecondPriceChange: React.Dispatch<React.SetStateAction<string>>;
   downTimeAfter: string;
   onDownTimeAfterChange: React.Dispatch<React.SetStateAction<string>>;
+  remainingDays: number;
   remainingTimes: number;
   startDate: Date;
   endDate: Date;
@@ -22,6 +24,7 @@ const SecondPriceTag = ({
   onSecondPriceChange,
   downTimeAfter,
   onDownTimeAfterChange,
+  remainingDays,
   remainingTimes,
   startDate,
   endDate,
@@ -29,15 +32,23 @@ const SecondPriceTag = ({
   const STD = format(startDate, "MM. dd (ccc) HH:mm", { locale: ko });
   const ETD = format(endDate, "MM. dd (ccc) HH:mm", { locale: ko });
 
+  const LEFTTIME = remainingDays * 24 + remainingTimes;
+  let processedTime: number | string = LEFTTIME;
+  if (LEFTTIME > 72) {
+    processedTime = `${remainingDays} 일  ${remainingTimes}`;
+  }
+
   useEffect(() => {
-    if (secondPriceData >= firstPrice) {
+    const processedfirstPrice = Number(firstPrice.split(",").join(""));
+    const processedSecondPrice = Number(secondPriceData.split(",").join(""));
+    if (processedSecondPrice >= processedfirstPrice) {
       // 만약 1차 가격을 내려서 2차 가격보다 낮아진다면 2차 가격은 최대 1차 가격 - 1000원으로 변경
-      let temp = Number(firstPrice) - 1000;
-      if (temp < 0) {
-        temp = 0;
+      let updated = processedfirstPrice - 1000;
+      if (updated < 0) {
+        updated = 0;
       }
 
-      onSecondPriceChange(temp.toString());
+      onSecondPriceChange(priceFormat(updated));
     }
   }, [firstPrice, secondPriceData, onSecondPriceChange]);
 
@@ -48,7 +59,11 @@ const SecondPriceTag = ({
         <S.Contents>
           <section>
             <h3>체크인</h3>
-            <span>{remainingTimes} 시간 남았어요</span>
+            <span>
+              {LEFTTIME > 72
+                ? `${processedTime} 시간 남았어요`
+                : `${processedTime} 시간 남았어요`}
+            </span>
           </section>
           <section>
             <h3>숙박일</h3>
@@ -64,7 +79,8 @@ const SecondPriceTag = ({
           text={["체크인", "시간전에"]}
           inputData={downTimeAfter}
           onDataChange={onDownTimeAfterChange}
-          remainingTimes={remainingTimes}
+          remainingTimes={LEFTTIME}
+          type="time"
         />
         <InputSection
           placeHolder="지정 가격"
@@ -72,7 +88,7 @@ const SecondPriceTag = ({
           text={["원으로 가격을 내릴게요"]}
           inputData={secondPriceData}
           onDataChange={onSecondPriceChange}
-          maxPrice={Number(firstPrice)}
+          maxPrice={Number(firstPrice.split(",").join(""))}
         />
       </S.Container>
       <S.Hr />

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -1,3 +1,4 @@
+import { ReactNode } from "react";
 import { IReservation } from "@/types/reservationList";
 import { IUserInfo } from "@/types/userInfo";
 
@@ -84,6 +85,30 @@ export const useUserInfoStore = create<UserState>((set) => ({
       userInfo: {
         ...state.userInfo,
         ...updatedInfo,
+      },
+    })),
+}));
+
+type configType = {
+  isShow: boolean;
+  strings: (string | ReactNode)[];
+};
+
+interface ToastStates {
+  config: configType;
+  setToastConfig: (updatedConfig: configType) => void;
+}
+
+export const useToastStore = create<ToastStates>((set) => ({
+  config: {
+    isShow: false,
+    strings: [],
+  },
+  setToastConfig: (updated) =>
+    set((state) => ({
+      config: {
+        ...state.config,
+        ...updated,
       },
     })),
 }));

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -91,6 +91,7 @@ export const useUserInfoStore = create<UserState>((set) => ({
 
 type configType = {
   isShow: boolean;
+  isError: boolean;
   strings: (string | ReactNode)[];
 };
 
@@ -102,6 +103,7 @@ interface ToastStates {
 export const useToastStore = create<ToastStates>((set) => ({
   config: {
     isShow: false,
+    isError: false,
     strings: [],
   },
   setToastConfig: (updated) =>

--- a/src/utils/priceFormat.ts
+++ b/src/utils/priceFormat.ts
@@ -1,4 +1,8 @@
-export default function priceFormat(n: number): string {
+export default function priceFormat(n: number | string): string {
+  if (typeof n === "string") {
+    n = Number(n);
+  }
+
   const reversedNumberArr: string[] = String(n).split("").reverse();
 
   //3자리씩 끊어서 쉼표 추가


### PR DESCRIPTION
### Issue Number

close https://github.com/SCBJ-7/SCBJ-FE/issues/85

### ⛳️ Task

- [x] 화이팅하기
- [x] 토스트 전역으로 수정
- [x] zustand-persist 사용
- [x] 예외 조건 처리
    - zustande-persist 구현
    - 2차 가격 판매 클릭 시 인풋 창 포커스
    - 인풋 포커스 해제할 시 100원 이하 날리기
    - priceFormatter에서 쉼표 처리하기
    - 3일 이상 ‘일’ 표시
    - 사용자가 입력 시 사이트에서 나가시겠습니까? 구현
    
### ✍️ Note

## 토스트 전역으로 수정
```javascript
// App.tsx
  return (
    <Layout>
      <AnimatePresence>{toastConfig.isShow && <Toast />}</AnimatePresence>
      <Outlet />
    </Layout>
  );
```

```javascript
// store.ts (zustand 파일)
type configType = {
  isShow: boolean; // 보이기 안 보이기
  strings: (string | ReactNode)[]; // string배열 (일단 기존 로직 그대로 가져왔습니다. 추후 리팩토링 때 나영님께서 제안하신 방식으로 수정..)
// 딜레이 시간은 삭제. 사용하는 곳에서 setTimeout으로 조절 
// 이유: 토스트의 useEffect와 토스트 사용하는 페이지의 useEffect 모두 전역변수 타이밍 조절하려드니까 순서 엉키더라구요. 
}; 

interface ToastStates {
  config: configType;
  setToastConfig: (updatedConfig: configType) => void;
}

export const useToastStore = create<ToastStates>((set) => ({
  config: { // 기본값
    isShow: false,
    strings: [],
  },
  setToastConfig: (updated) => // 수정 함수
    set((state) => ({
      config: {
        ...state.config, //
        ...updated,
      },
    })),
}));
```

```javascript
// 토스트 쓰고 싶은 곳
  useEffect(() => {
    setToastConfig({
      isShow: true, // 쓰고 싶은 곳에서 useEffect로 발동
      strings: [<>야놀자</>, "에서 예약하신 상품만 판매 가능해요."],
    }); 
    setTimeout(() => {
      setToastConfig({
        isShow: false,
        strings: [<>야놀자</>, "에서 예약하신 상품만 판매 가능해요."],
      });
    }, 3000);  // 3초 뒤 사라지게 하기
  }, [setToastConfig]);
```


```javascript
// App.tsx
  const toastConfig = useToastStore((state) => state.config);
  const setToastConfig = useToastStore((state) => state.setToastConfig);
  const location = useLocation();

  useEffect(() => { // 페이지 이동에 따라 isShow: false해줍니다. 다른 페이지로 계속 왔다갔다해도 토스트가 3초간 계속 떠있어서..
    setToastConfig({
      isShow: false,
      strings: toastConfig.strings,
    });
    // eslint-disable-next-line react-hooks/exhaustive-deps 
    // 위 주석은 useEffect 의존성배열에 대한 eslint 설정 제외하는 주석입니다. 
    // isShow나 strings같은 것도 의존성 배열에 넣기를 강제하는데 pathname에만 반응해야 원하는대로 반응하기 때문에 린트설정 제외 
  }, [location.pathname]); 
```

## Zustand-persist 사용 예시
```javascript
// 예약내역 선택 아이템 전역상태 store
export const useSelectedItemStore = create(
  persist<ReservationState>(
    (set) => ({
      // 데이터 기본값
      selectedItem: {
        reservationId: 0,
        hotelName: "",
        roomName: "",
        startDate: new Date(),
        endDate: new Date(),
        refundPrice: 0,
        purchasePrice: 0,
        remainingDays: 0,
        remainingTimes: 0,
        imageUrl: "",
      },
      // 데이터 조작 set 함수
      setSelectedItem: (updatedItem) =>
        set((state) => ({
          selectedItem: {
            ...state.selectedItem,
            ...updatedItem,
          },
        })),
    }),
    {
      name: "reservationStorage",
    },
  ),
);
```
예약내역페이지 -> 가격설정 페이지 데이터 전송을 쿼리스트링으로 하다가
전역변수로 바꿨는데 새로고침하면 날라가서 도입했습니다.

## usePreventLeave 훅 추가
정보 다 입력했는데 실수로 뒤로가기나 다른 버튼을 눌렀을 때 아래와 같은 창으로 나가기 방지 해주는 훅

<img width="532" alt="image" src="https://github.com/SCBJ-7/SCBJ-FE/assets/126222848/04084ead-1d24-4775-ae64-b5afc60d3749">

```javascript
const TransferWritingPrice = () => {
  usePreventLeave(true); // 컴포넌트 내에서 함수 실행에 true 패러미터만 주면 페이지 전체에 적용됩니다.
```

## 데이터 입력 시 쉼표 추가

- 쉼표 추가
- 판매가 이상으로 설정 시 자동으로 판매가로 설정 ...
- 1차 가격이 없는 상태로 2차 가격 설정하기 체크박스를 누르면 1차 가격 인풋에 자동 포커스
- 
https://github.com/SCBJ-7/SCBJ-FE/assets/126222848/087c3428-efff-473f-83b7-3419f1542dc9

우아하게 구현은 못했고
PriceState가 "100,000"이라고 치면

```javascript
priceFormat(priceState.split(",").join("")))
```
를 해줬습니다. 
(priceFormat은 Number()를 했을 때 NaN이 되지 않는 string은 허용함)




### 📸 Screenshot

### 📎 Reference
