### PR TITLE
[#100] 야놀자 연동 페이지 404 에러 시 토스트 메시지 띄우기

### DIFF
--- a/src/apis/axiosInstance.ts
+++ b/src/apis/axiosInstance.ts
@@ -1,7 +1,7 @@
 import axios from "axios";
 
 export const axiosInstance = axios.create({
-  baseURL: "/v1",
+  baseURL: "https://3.34.147.187.nip.io",
   timeout: 5000,
   withCredentials: true,
 });

--- a/src/apis/postValidateEmail.ts
+++ b/src/apis/postValidateEmail.ts
@@ -1,0 +1,8 @@
+import { axiosInstance } from "@apis/axiosInstance";
+import { END_POINTS } from "@/constants/api";
+
+export const postValidateEmail = async (email: string) => {
+  const { data } = await axiosInstance.post(END_POINTS.EMAIL, { email });
+  console.log(data.data);
+  return data.data;
+};

--- a/src/apis/postYanoljaAccount.ts
+++ b/src/apis/postYanoljaAccount.ts
@@ -1,0 +1,16 @@
+import { axiosInstance } from "@apis/axiosInstance";
+import { END_POINTS } from "@/constants/api";
+
+export const postYanoljaAccount = async (email: string) => {
+  const { data } = await axiosInstance.post(
+    END_POINTS.YANOLJA,
+    { email },
+    {
+      headers: {
+        Authorization: `${localStorage.getItem("accessToken")}`,
+        "Content-Type": "application/json",
+      },
+    },
+  );
+  return data.data;
+};

--- a/src/hooks/api/mutation/useConnectAccountMutation.ts
+++ b/src/hooks/api/mutation/useConnectAccountMutation.ts
@@ -1,6 +1,6 @@
 import { END_POINTS } from "@constants/api";
 import { useMutation } from "@tanstack/react-query";
-import axios from "axios";
+import axios, { isAxiosError } from "axios";
 import { useNavigate } from "react-router-dom";
 
 import { PATH } from "@/constants/path";
@@ -19,21 +19,24 @@ export const useConnectAccountMutation = () => {
         replace: true,
       });
     },
-    onError: () => {
-      // FIXME: jsx 반환이 안돼서 문자열로 처리, but 수정이 필요함
-      const message = "입력한 정보를 다시 확인해주세요";
-      setToastConfig({
-        isShow: true,
-        isError: false,
-        strings: [message],
-      });
-      setTimeout(() => {
+    onError: (error) => {
+      if (!isAxiosError(error)) return;
+      if (error.response && error.response.status === 404) {
+        // FIXME: jsx 반환이 안돼서 문자열로 처리, but 수정이 필요함
+        const message = "입력한 정보를 다시 확인해주세요";
         setToastConfig({
-          isShow: false,
+          isShow: true,
           isError: false,
           strings: [message],
         });
-      }, 6000);
+        setTimeout(() => {
+          setToastConfig({
+            isShow: false,
+            isError: false,
+            strings: [message],
+          });
+        }, 6000);
+      }
     },
   });
 

--- a/src/hooks/api/mutation/useConnectAccountMutation.ts
+++ b/src/hooks/api/mutation/useConnectAccountMutation.ts
@@ -4,9 +4,11 @@ import axios from "axios";
 import { useNavigate } from "react-router-dom";
 
 import { PATH } from "@/constants/path";
+import { useToastStore } from "@store/store";
 
 export const useConnectAccountMutation = () => {
   const navigate = useNavigate();
+  const setToastConfig = useToastStore((state) => state.setToastConfig);
 
   const connectAccountMutation = useMutation({
     mutationFn: (email) =>
@@ -18,7 +20,20 @@ export const useConnectAccountMutation = () => {
       });
     },
     onError: () => {
-      // 여기서 에러 핸들링 필요
+      // FIXME: jsx 반환이 안돼서 문자열로 처리, but 수정이 필요함
+      const message = "입력한 정보를 다시 확인해주세요";
+      setToastConfig({
+        isShow: true,
+        isError: false,
+        strings: [message],
+      });
+      setTimeout(() => {
+        setToastConfig({
+          isShow: false,
+          isError: false,
+          strings: [message],
+        });
+      }, 6000);
     },
   });
 

--- a/src/hooks/api/mutation/useConnectAccountMutation.ts
+++ b/src/hooks/api/mutation/useConnectAccountMutation.ts
@@ -21,7 +21,6 @@ export const useConnectAccountMutation = () => {
     onError: (error) => {
       if (!isAxiosError(error)) throw error;
       if (error.response && error.response.status === 404) {
-        // FIXME: jsx 반환이 안돼서 문자열로 처리, but 수정이 필요함
         const message = "입력한 정보를 다시 확인해주세요";
         setToastConfig({
           isShow: true,

--- a/src/hooks/api/mutation/useConnectAccountMutation.ts
+++ b/src/hooks/api/mutation/useConnectAccountMutation.ts
@@ -20,7 +20,7 @@ export const useConnectAccountMutation = () => {
       });
     },
     onError: (error) => {
-      if (!isAxiosError(error)) return;
+      if (!isAxiosError(error)) throw error;
       if (error.response && error.response.status === 404) {
         // FIXME: jsx 반환이 안돼서 문자열로 처리, but 수정이 필요함
         const message = "입력한 정보를 다시 확인해주세요";

--- a/src/hooks/api/mutation/useConnectAccountMutation.ts
+++ b/src/hooks/api/mutation/useConnectAccountMutation.ts
@@ -1,18 +1,17 @@
-import { END_POINTS } from "@constants/api";
 import { useMutation } from "@tanstack/react-query";
-import axios, { isAxiosError } from "axios";
+import { isAxiosError } from "axios";
 import { useNavigate } from "react-router-dom";
 
-import { PATH } from "@/constants/path";
 import { useToastStore } from "@store/store";
+import { postYanoljaAccount } from "@apis/postYanoljaAccount";
+import { PATH } from "@constants/path";
 
 export const useConnectAccountMutation = () => {
   const navigate = useNavigate();
   const setToastConfig = useToastStore((state) => state.setToastConfig);
 
   const connectAccountMutation = useMutation({
-    mutationFn: (email) =>
-      axios.post(`https://3.34.147.187.nip.io${END_POINTS.YANOLJA}`, { email }),
+    mutationFn: (email: string) => postYanoljaAccount(email),
     onSuccess: () => {
       navigate(PATH.YANOLJA_ACCOUNT_VERIFY + "/success", {
         state: { success: true },

--- a/src/hooks/api/mutation/useValidateEmailMutation.ts
+++ b/src/hooks/api/mutation/useValidateEmailMutation.ts
@@ -6,8 +6,6 @@ export const useValidateEmailMutation = () => {
   const validateEmailMutation = useMutation({
     mutationFn: (email: { email: string }) =>
       axios.post(`https://3.34.147.187.nip.io${END_POINTS.EMAIL}`, { email }),
-
-    // FIXME: 엣지 케이스 추가
   });
 
   return validateEmailMutation;

--- a/src/hooks/api/mutation/useValidateEmailMutation.ts
+++ b/src/hooks/api/mutation/useValidateEmailMutation.ts
@@ -1,11 +1,9 @@
-import { END_POINTS } from "@constants/api";
+import { postValidateEmail } from "@apis/postValidateEmail";
 import { useMutation } from "@tanstack/react-query";
-import axios from "axios";
 
 export const useValidateEmailMutation = () => {
   const validateEmailMutation = useMutation({
-    mutationFn: (email: { email: string }) =>
-      axios.post(`https://3.34.147.187.nip.io${END_POINTS.EMAIL}`, { email }),
+    mutationFn: ({ email }: { email: string }) => postValidateEmail(email),
   });
 
   return validateEmailMutation;

--- a/src/pages/connectYanoljaPage/verificationPage/components/submitButton/SubmitButton.tsx
+++ b/src/pages/connectYanoljaPage/verificationPage/components/submitButton/SubmitButton.tsx
@@ -15,7 +15,6 @@ const SubmitButton = () => {
   const onSubmit = () => {
     const email = getValues("email");
     if (!email) return;
-
     connectAccountMutation.mutate(email);
   };
 

--- a/src/pages/connectYanoljaPage/verificationPage/components/verificationSection/VerificationSection.tsx
+++ b/src/pages/connectYanoljaPage/verificationPage/components/verificationSection/VerificationSection.tsx
@@ -1,13 +1,13 @@
 import InputField from "@components/inputField/InputField";
 import { useValidateEmailMutation } from "@hooks/api/mutation/useValidateEmailMutation";
 import axios from "axios";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useFormContext } from "react-hook-form";
 
 import * as S from "./VerificationSection.style.ts";
 
 const VerificationSection = () => {
-  const { control, getValues, setError, clearErrors } = useFormContext();
+  const { control, getValues, setError, clearErrors, watch } = useFormContext();
   const [isEmailValidated, setIsEmailValidated] = useState(false);
   const [isCodeValidated, setIsCodeValidated] = useState(false);
   const [codeState, setCodeState] = useState("######");
@@ -31,17 +31,22 @@ const VerificationSection = () => {
     });
   };
 
-  const handleValidationCodeClick = () => {
-    const code = getValues("code");
+  const code = watch("code");
 
-    if (code === codeState) {
-      setIsCodeValidated(true);
-      clearErrors("code");
-    } else {
-      setIsCodeValidated(false);
-      setError("code", { message: "잘못된 인증번호입니다" });
-    }
+  useEffect(() => {
+    setIsCodeValidated(false);
+  }, [code]);
+
+  const handleValidationCodeClick = () => {
+    const isValid = code === codeState;
+
+    setIsCodeValidated(isValid);
+
+    isValid
+      ? clearErrors("code")
+      : setError("code", { message: "인증번호를 다시 입력해주세요" });
   };
+
   return (
     <S.MainWrapper>
       <InputField

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -35,7 +35,8 @@
       "@mocks/*": ["./src/mocks/*"],
       "@routes/*": ["./src/routes/*"],
       "@utils/*": ["./src/utils/*"],
-      "@type/*": ["./src/types/*"]
+      "@type/*": ["./src/types/*"],
+      "@store/*": ["./src/store/*"]
     }
   },
   "include": ["src", "tests"],

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -28,6 +28,7 @@ export default defineConfig({
       "@routes": path.resolve(__dirname, "./src/routes"),
       "@utils": path.resolve(__dirname, "./src/utils"),
       "@type": path.resolve(__dirname, "./src/types"),
+      "@store": path.resolve(__dirname, "./src/store"),
     },
   },
 });


### PR DESCRIPTION
### Issue Number

close #100

### ⛳️ Task

- [x] 화이팅하기
- [x] 야놀자 계정을 찾을 수 없는 경우 404 에러 발생 -> 토스트 메시지 띄움
- [x] 인증번호 오입력 시 에러 메시지 수정
- [x] 인증번호 필드 입력할 때 마다 `isCodeValidated` 값 초기화

### ✍️ Note
야놀자 연동하기 버튼을 눌렀을 때 야놀자 계정을 찾을 수 없는 경우 토스트 메시지를 띄워줍니다.

```typescript
      onError: (error) => {
      if (!isAxiosError(error)) throw error; // 서버 에러가 아닐 경우 에러바운더리로 던짐
      if (error.response && error.response.status === 404) { // 404 에러 인 경우만 처리
        // FIXME: jsx 반환이 안돼서 문자열로 처리, but 수정이 필요함
        const message = "입력한 정보를 다시 확인해주세요";
        setToastConfig({
          isShow: true,
          isError: false,
          strings: [message],
        });
        setTimeout(() => {
          setToastConfig({
            isShow: false,
            isError: false,
            strings: [message],
          });
        }, 6000);
      }
    }
``` 
mutation 훅의 onError 옵션에 토스트 메시지를 띄우는 걸로  처리했습니다.
토스트 컴포넌트의 경우, ReactNode 형식으로 반환해야 red color가 적용되는데 훅 파일이 jsx를 반환하지 않아서 일단 string 타입을 사용했습니다...! // 이부분 훅 파일이 jsx 반환하도록 고치는게 맞을까욥..?

### 📸 Screenshot
#### 야놀자계정찾기_errorcase_계정불일치
<img width="542" alt="스크린샷 2024-01-16 오전 1 57 52" src="https://github.com/SCBJ-7/SCBJ-FE/assets/139189221/bb020609-51f7-4921-9923-52b5b474ec31">


#### 야놀자계정찾기_errorcase_인증번호 오입력
<img width="535" alt="스크린샷 2024-01-16 오전 1 58 01" src="https://github.com/SCBJ-7/SCBJ-FE/assets/139189221/b24b73d1-cdbc-417c-82c1-13b93411cb4f">


혹시 더 수정할 부분 있으면 말씀부탁드리겠습니다 😄

### 📎 Reference
