### PR TITLE
[#117] axios 공통 instance 사용 및 계좌 및 프로필 페이지 return 구조 변경

### DIFF
--- a/src/apis/patchAccount.ts
+++ b/src/apis/patchAccount.ts
@@ -1,9 +1,9 @@
-import { instance } from "@apis/useProfileApi";
 import { END_POINTS } from "@constants/api";
-import { AccountProps } from "@type/account";
+import type { AccountProps } from "@type/account";
+import { axiosInstance } from "./axiosInstance";
 
 export const patchAccount = async (accountData: AccountProps) => {
-  const { data } = await instance.patch(END_POINTS.ACCOUNT, accountData);
+  const { data } = await axiosInstance.patch(END_POINTS.ACCOUNT, accountData);
 
   return data.data;
 };

--- a/src/apis/useProfileApi.ts
+++ b/src/apis/useProfileApi.ts
@@ -1,50 +1,22 @@
-import axios from "axios";
-
-const getAuth = () => {
-  if (localStorage.getItem("AccessToken")) {
-    const token = localStorage.getItem("AccessToken");
-    return token;
-  }
-};
-
-const baseUrl = import.meta.env.VITE_SERVER_URL;
-
-export const instance = axios.create({
-  baseURL: baseUrl,
-  headers: { Authorization: `Bearer  + ${getAuth()}` },
-});
-
-instance.interceptors.request.use(
-  (config) => {
-    const token = getAuth();
-    if (token) {
-      config.headers.Authorization = `Bearer ${token}`;
-    }
-    return config;
-  },
-  (error) => {
-    console.log("interceptor request error: ", error);
-    Promise.reject(error);
-  },
-);
+import { axiosInstance } from "./axiosInstance";
 
 const useProfileApi = () => {
   const getProfileData = async (endPoint: string) => {
     const apiURL = `${endPoint}`;
-    const { data } = await instance.get(apiURL);
+    const { data } = await axiosInstance.get(apiURL);
 
     return data.data;
   };
 
   const changeName = async (endPoint: string, name: string) => {
     const apiURL = `${endPoint}`;
-    const res = await instance.patch(apiURL, { name });
+    const res = await axiosInstance.patch(apiURL, { name });
     return res;
   };
 
   const changeNumber = async (endPoint: string, number: string) => {
     const apiURL = `${endPoint}`;
-    const res = await instance.patch(apiURL, { phone: number });
+    const res = await axiosInstance.patch(apiURL, { phone: number });
     return res;
   };
 

--- a/src/pages/myPage/manage/manageAccount/ManageAccount.tsx
+++ b/src/pages/myPage/manage/manageAccount/ManageAccount.tsx
@@ -5,21 +5,19 @@ import { useEffect, useState } from "react";
 import EnterAccountInfo from "@components/account/enterAccountInfo/EnterAccountInfo";
 import type { AccountProps } from "@type/account";
 import AccountInfo from "../accountInfo/AccountInfo";
-import useToastConfig from "@hooks/common/useToastConfig";
 import { END_POINTS } from "@constants/api";
 import { useLocation } from "react-router-dom";
 
 const ManageAccount = () => {
   const { search: step } = useLocation();
   const { getProfileData } = useProfileApi();
-  const { handleToast } = useToastConfig();
   const [data, setData] = useState<ProfileData>();
   const noPrevAccount = !data?.accountNumber && !data?.bank;
   const [accountInfo, setAccountInfo] = useState<AccountProps>({
     accountNumber: data?.accountNumber,
     bank: data?.bank,
   });
-  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
   const [isEditing, setIsEditing] = useState<boolean>(false);
 
   const fetchData = async () => {
@@ -28,8 +26,8 @@ const ManageAccount = () => {
       const res = await getProfileData(END_POINTS.USER_INFO);
       setData(res);
       setAccountInfo({ accountNumber: res.accountNumber, bank: res.bank });
-    } catch {
-      handleToast(true, [<>fetching err</>]);
+    } catch (error) {
+      console.log(error);
     } finally {
       setIsLoading(false);
     }
@@ -46,23 +44,22 @@ const ManageAccount = () => {
     setIsEditing(state);
   };
 
-  return (
-    <>
-      {isLoading ? (
-        <div>Loading</div>
-      ) : noPrevAccount ? (
-        <RegisterAccount />
-      ) : isEditing ? (
-        <EnterAccountInfo
-          accountInfo={accountInfo}
-          setAccountInfo={setAccountInfo}
-          setIsEditing={setIsEditing}
-        />
-      ) : (
-        <AccountInfo data={data} onClick={() => setEditState(true)} />
-      )}
-    </>
-  );
+  if (isLoading) return <div>Loading...</div>;
+
+  if (!data) return <div>Data fetching Error</div>;
+
+  if (noPrevAccount) return <RegisterAccount />;
+
+  if (isEditing)
+    return (
+      <EnterAccountInfo
+        accountInfo={accountInfo}
+        setAccountInfo={setAccountInfo}
+        setIsEditing={setIsEditing}
+      />
+    );
+
+  return <AccountInfo data={data} onClick={() => setEditState(true)} />;
 };
 
 export default ManageAccount;

--- a/src/pages/myPage/manage/manageProfile/ManageProfile.tsx
+++ b/src/pages/myPage/manage/manageProfile/ManageProfile.tsx
@@ -4,34 +4,46 @@ import ManagePhoneNumber from "../managePhoneNumber/ManagePhoneNumber";
 import * as S from "./ManageProfile.style";
 import useProfileApi from "@/apis/useProfileApi";
 import type { ProfileData } from "./ManageProfile.type";
-import { useQuery } from "@tanstack/react-query";
-import { AxiosError } from "axios";
+import { useEffect, useState } from "react";
+import { END_POINTS } from "@constants/api";
 
 const ManageProfile = () => {
   const { getProfileData } = useProfileApi();
-  const { data } = useQuery<ProfileData, AxiosError>({
-    queryKey: ["profile"],
-    queryFn: () => getProfileData("/v1/members"),
-  });
+  const [userProfile, setUserProfile] = useState<ProfileData>();
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+
+  const fetchUserProfile = async () => {
+    try {
+      const res = await getProfileData(END_POINTS.USER_INFO);
+      setUserProfile(res);
+    } catch (err) {
+      console.log(err);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchUserProfile();
+    // eslint-disable-next-line
+  }, []);
+
+  if (isLoading) return <div>Loading...</div>;
+
+  if (!userProfile) return <div>Data Fetching Error</div>;
 
   return (
-    <>
-      {data ? (
-        <S.ManageContainer>
-          <h1>나의 계정</h1>
-          <S.ManageInfoWrapper>
-            <ManageEmail email={data.email} />
-            <ManageName
-              prevName={data.name}
-              linkedToYanolja={data.linkedToYanolja}
-            />
-            <ManagePhoneNumber prevPhoneNumber={data.phone} />
-          </S.ManageInfoWrapper>
-        </S.ManageContainer>
-      ) : (
-        <div>Data Fetching Error</div>
-      )}
-    </>
+    <S.ManageContainer>
+      <h1>나의 계정</h1>
+      <S.ManageInfoWrapper>
+        <ManageEmail email={userProfile?.email} />
+        <ManageName
+          prevName={userProfile?.name}
+          linkedToYanolja={userProfile?.linkedToYanolja}
+        />
+        <ManagePhoneNumber prevPhoneNumber={userProfile?.phone} />
+      </S.ManageInfoWrapper>
+    </S.ManageContainer>
   );
 };
 


### PR DESCRIPTION
### Issue Number

close #117 

### ⛳️ Task

- [x] 화이팅하기
- [x] axios 공통 instance 사용
- [x] 계좌 및 프로필 페이지 리팩터

### ✍️ Note
**계좌 및 프로필 관련 api 호출 시, axios 공통 instance를 사용하도록 수정했습니다**

**_바쁘신 분들은 하단 3줄 결론만 읽으셔도 됩니다!_**
react-query에 대해서 많이 고민을 했는데, 저는 캐싱이 필요없는 페이지에서는 사용하지 않도록 결정했습니다.
(ManageProfile.tsx에서 useQuery를 이용하던 것을 try-catch 문과 useEffect를 사용하는 방법으로 변경했습니다.)


- **캐싱이 필요한가?**
   캐싱이 필요 없을 경우 staleTime이나 gcTime(이전 버전 "cacheTime") 을 통해 캐시하지 않도록 설정을 할 수 있지만, 굳이 이 옵션을 추가하면서까지 사용할 필요는 없다고 생각했습니다.
   
- **isLoading/isError 옵션 사용**
isLoading과 isError를 제공해준다는 점은 편하지만 이것을 사용하기 위해 react-query를 사용한다? 는 고민을 했습니다. 멘토님께서 말씀해 주신대로 불필요하게 사용된 react-query는 이후 **리팩토링이나 유지 보수할 때, 불편함**을 줄 수 있다고 생각했습니다.

  **isLoading**은 state를 통해 관리했고 
**isError**는 fetch Error일 경우 [data, setData]의 data falsy를 검사하여 관리하고 / post,patch 에러의 경우 catch문을 통해 관리합니다.

- **커스텀 훅을 통한 데이터 가공 혹은 에러 핸들링**
https://github.com/SCBJ-7/SCBJ-FE/pull/112#discussion_r1456919324

  @im-na0 님이 코멘트 달아주신 것을 보고 고민을 많이 했습니다. 실제로 useMutation을 사용하신 훅을 보고 생각을 더 해보기도 했습니다.
우선 예시로 같은 **유저 프로필** 데이터를 받는다고 했을 때, 데이터 가공 시 **이메일, 이름이 필요한 페이지**가 있고, **계좌 정보만 필요한 페이지**가 있습니다. 그리고 다른 에러 처리가 필요할 때도 있습니다. 우선 저는 post, patch 요청에서 error가 발생했을 때는 toast를 보여줄 생각이고 get요청에서 error가 발생했을 때는 toast가 아닌 **에러 화면을 커스텀**해서 보여줄 예정입니다.  post나 patch의 경우 특정 api가 여러 페이지에서 사용될 일은 거의 없기 때문에 굳이 훅을 만들 필요가 없을 것이고 , get의 경우도 커스텀된 에러 화면을 보여주기 때문에 훅이 불필요하다 생각했습니다. (훅에서 커스텀된 ReactNode 요소를 전달받아서 에러 컴포넌트로 return 할 수는 있지만, 드물다고 생각하였고 확장성이 좋다고 판단하지는 않았습니다)

  결론으로, 소수의 api들만이 여러 페이지에서 사용되는데, 그마저도 데이터 가공이나 에러 핸들링 방식에 차이가 있다고 판단하여 훅은 사용하지 않을 예정입니다. (데이터 가공이나 에러 핸들링 로직이 너무 길어 한 파일 내에서 가독성이 떨어진다면 파일을 분리하는 방식으로 진행할 예정입니다)

---
### 결론
멘토님께서 해주신 내용이나 pr 리뷰 내용 읽으면서 많이 생각을 하고, 로컬 브랜치에서 방식을 엎어보며 코드를 짜봤는데 결국 이렇게 결론을 내렸습니다.
1. 데이터 가공과 글로벌 에러를 제외한 로컬 에러는 각 페이지에서 처리
2.  useQuery, useSuspenseQuery는 캐싱이 필요 없는 호출에서는 사용하지 않음
3. useMutation은 사용하지만, 훅으로 분리하진 않을 예정

### 📸 Screenshot

### 📎 Reference
