### PR TITLE
[#155] 결제 페이지 조회 전 재고 확인

### DIFF
--- a/src/apis/fetchPayment.ts
+++ b/src/apis/fetchPayment.ts
@@ -1,8 +1,15 @@
 import { axiosInstance } from "@apis/axiosInstance";
 import { END_POINTS } from "@constants/api";
-import type { PaymentData, PaymentRequestData } from "@type/payment";
+import type { StockData, PaymentData, PaymentRequestData } from "@type/payment";
 import type { ResponseData } from "@type/responseType";
 import type { Nullable } from "@type/nullable";
+
+export const getStock = async (productId: string): Promise<StockData> => {
+  const { data } = await axiosInstance.get<ResponseData<StockData>>(
+    END_POINTS.STOCK(productId),
+  );
+  return data.data;
+};
 
 export const getPayment = async (productId: string): Promise<PaymentData> => {
   const { data } = await axiosInstance.get<ResponseData<PaymentData>>(

--- a/src/apis/fetchPayment.ts
+++ b/src/apis/fetchPayment.ts
@@ -11,13 +11,6 @@ export const getStock = async (productId: string): Promise<StockData> => {
   return data.data;
 };
 
-export const getStock = async (productId: string): Promise<StockData> => {
-  const { data } = await axiosInstance.get<ResponseData<StockData>>(
-    END_POINTS.STOCK(productId),
-  );
-  return data.data;
-};
-
 export const getPayment = async (productId: string): Promise<PaymentData> => {
   const { data } = await axiosInstance.get<ResponseData<PaymentData>>(
     END_POINTS.PAYMENT(productId),

--- a/src/apis/fetchPayment.ts
+++ b/src/apis/fetchPayment.ts
@@ -11,6 +11,13 @@ export const getStock = async (productId: string): Promise<StockData> => {
   return data.data;
 };
 
+export const getStock = async (productId: string): Promise<StockData> => {
+  const { data } = await axiosInstance.get<ResponseData<StockData>>(
+    END_POINTS.STOCK(productId),
+  );
+  return data.data;
+};
+
 export const getPayment = async (productId: string): Promise<PaymentData> => {
   const { data } = await axiosInstance.get<ResponseData<PaymentData>>(
     END_POINTS.PAYMENT(productId),

--- a/src/apis/fetchRoom.ts
+++ b/src/apis/fetchRoom.ts
@@ -3,9 +3,9 @@ import type { ResponseData } from "@type/responseType";
 import type { RoomData } from "@type/room";
 import axios from "axios";
 
-export const getRoom = async (roomId: string): Promise<RoomData> => {
+export const getRoom = async (productId: string): Promise<RoomData> => {
   const { data } = await axios.get<ResponseData<RoomData>>(
-    BASE_URL + END_POINTS.ROOM(roomId),
+    BASE_URL + END_POINTS.ROOM(productId),
   );
   return data.data;
 };

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -16,21 +16,9 @@ const Layout = ({ children }: ChildrenProps) => {
 
   // FIXME: 헤더, 네비바 특정 페이지에서만 보이지 않도록 수정 필요
   // 이럼 account/yanolja/verify 이런 하위 페이지도 같이 include 됨
-  const pathsToExcludeHeader = [
-    PATH.LOGIN,
-    PATH.DETAIL_ROOM,
-    PATH.YANOLJA_ACCOUNT,
-    PATH.WRITE_TRANSFER_PRICE,
-    PATH.WRITE_TRANSFER_SUCCESS,
-  ];
+  const pathsToExcludeHeader = [PATH.LOGIN, PATH.WRITE_TRANSFER_PRICE];
 
-  const pathsToExcludeBottom = [
-    PATH.LOGIN,
-    PATH.DETAIL_ROOM,
-    PATH.YANOLJA_ACCOUNT,
-    PATH.SEARCH_FILTER,
-    PATH.PURCAHSE_DEATAIL,
-  ];
+  const pathsToExcludeBottom = [PATH.LOGIN, PATH.SEARCH_FILTER];
 
   let isHeaderOn = !pathsToExcludeHeader.some((path) =>
     pathname.includes(path),

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -22,7 +22,7 @@ export const END_POINTS = {
     `/v1/products/${productId}/payments?paymentType=${paymentType}`,
   PAYMENT_SUCCESS: (paymentType: string, pgToken: string) =>
     `/v1/products/pay-success?paymentType=${paymentType}&pg_token=${pgToken}`,
-
+  STOCK: (productId: string) => `/v1/products/${productId}/stock`,
   NEW_TOKEN: "/v1/token/refresh",
 } as const;
 

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -6,7 +6,7 @@ export const END_POINTS = {
   SIGNUP: "/v1/members/signup",
   ALARM: "/v1/alarms",
   HASALARM: "/v1/alarms/status",
-  ROOM: (roomId: string) => `/v1/products/${roomId}`,
+  ROOM: (productId: string) => `/v1/products/${productId}`,
   RESERVATION: "/v1/reservations",
   MAIN: "/v1/products/main",
   USER_INFO: "/v1/members",

--- a/src/constants/path.ts
+++ b/src/constants/path.ts
@@ -8,7 +8,7 @@ export const PATH = {
   PURCHASE_LIST: "/my-page/purchase-list",
   PURCAHSE_DEATAIL: "/my-page/purchase-detail",
   SALE_DETAIL: "/my-page/sale-detail",
-  DETAIL_ROOM: "/room",
+  DETAIL_ROOM: (productId: string) => `/room/${productId}`,
   WRITE_TRANSFER: "/transfer/new",
   WRITE_TRANSFER_PRICE: "/transfer/new/price",
   WRITE_TRANSFER_SUCCESS: "/transfer/new/success",
@@ -24,7 +24,6 @@ export const PATH = {
   YANOLJA_ACCOUNT: "/account/yanolja",
   RELOAD: 0,
   PAYMENT: (productId: string) => `/payment/${productId}`,
-  PAYMENT_READY: (productId: string) => `/payment/${productId}/ready`,
   PAYMENT_SUCCESS: (productId: string) => `/payment/${productId}/success`,
 } as const;
 // 참고

--- a/src/constants/path.ts
+++ b/src/constants/path.ts
@@ -8,7 +8,7 @@ export const PATH = {
   PURCHASE_LIST: "/my-page/purchase-list",
   PURCAHSE_DEATAIL: "/my-page/purchase-detail",
   SALE_DETAIL: "/my-page/sale-detail",
-  DETAIL_ROOM: (productId: string) => `/room/${productId}`,
+  DETAIL_ROOM: (productId: string | number) => `/room/${productId}`,
   WRITE_TRANSFER: "/transfer/new",
   WRITE_TRANSFER_PRICE: "/transfer/new/price",
   WRITE_TRANSFER_SUCCESS: "/transfer/new/success",

--- a/src/hooks/api/mutation/usePaymentMutation.ts
+++ b/src/hooks/api/mutation/usePaymentMutation.ts
@@ -8,7 +8,6 @@ export const usePaymentMutation = () => {
     mutationFn: (paymentRequest: PaymentRequestProps) =>
       postPayment(paymentRequest),
     onSuccess: (data) => {
-      console.log(data);
       const payUrl = data.url.toString();
       window.location.href = payUrl;
     },

--- a/src/hooks/api/useStockQuery.ts
+++ b/src/hooks/api/useStockQuery.ts
@@ -1,0 +1,11 @@
+import { getStock } from "@apis/fetchPayment";
+import { useQuery } from "@tanstack/react-query";
+
+export const useStockQuery = (productId: string) => {
+  return useQuery({
+    queryKey: ["stock", productId],
+    queryFn: () => getStock(productId),
+    enabled: false,
+    throwOnError: true,
+  });
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,7 +3,7 @@ import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import ReactDOM from "react-dom/client";
 import { RouterProvider } from "react-router-dom";
 import { ThemeProvider } from "styled-components";
-// import { worker } from "./mocks/broswer";
+import { worker } from "./mocks/broswer";
 import { router } from "./routes/router";
 import { GlobalStyle } from "./styles/globalStyle";
 import { theme } from "./styles/theme";
@@ -15,9 +15,12 @@ const queryClient = new QueryClient({
     },
   },
 });
-// if (process.env.NODE_ENV === "development") {
-//   worker.start();
-// }
+
+if (process.env.NODE_ENV === "development") {
+  worker.start({
+    onUnhandledRequest: "bypass",
+  });
+}
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <QueryClientProvider client={queryClient}>

--- a/src/mocks/data/dummyRoomDetail.json
+++ b/src/mocks/data/dummyRoomDetail.json
@@ -21,8 +21,8 @@
     },
     "hotelAddress": "서울특별시 강남구 테헤란로 99길 9",
     "hotelInfoUrl": "https://place-site.yanolja.com/places/3001615",
-    "saleStatus": false,
-    "isSeller": true
+    "saleStatus": true,
+    "isSeller": false
   },
   "message": "상품 조회에 성공했습니다."
 }

--- a/src/mocks/data/dummyStock.json
+++ b/src/mocks/data/dummyStock.json
@@ -1,0 +1,1 @@
+{ "message": "상품 재고 조회에 성공했습니다.", "data": { "hasStock": false } }

--- a/src/mocks/handler.ts
+++ b/src/mocks/handler.ts
@@ -5,15 +5,16 @@ import dummyPurchaseList from "./data/dummyPuchaseList.json";
 import dummyPurchaseDetail from "./data/dummyPurchaseDetail.json";
 import dummySearchList from "./data/dummySearchList.json";
 import dummyRoom from "./data/dummyRoomDetail.json";
-// import userInfo from "./data/userInfo.json";
-import { roomHandlers } from "./handlers/room";
+import roomHandlers from "./handlers/room";
 import { paymentHandler } from "./handlers/payment";
-// import emailHandlers from "./handlers/email";
+import emailHandlers from "./handlers/email";
+import yanoljaAccountHandlers from "./handlers/yanoljaAccount";
 
 export const handlers = [
   ...roomHandlers,
   ...paymentHandler,
-  // ...Object.values(emailHandlers),
+  ...Object.values(emailHandlers),
+  ...Object.values(yanoljaAccountHandlers),
   http.get("/api/roomId", () => {
     return HttpResponse.json(dummyRoom);
   }),

--- a/src/mocks/handlers/email.ts
+++ b/src/mocks/handlers/email.ts
@@ -6,21 +6,21 @@ export const getEmailVerification = (scenarioProps?: string) => {
     const pageParams = new URLSearchParams(window.location.search);
     const scenario = pageParams.get("scenario");
 
-    if (scenario || scenarioProps === "error1") {
+    if (scenario || scenarioProps === "E01") {
       return HttpResponse.json(
         { message: "공백이 없어야 합니다." },
         { status: 400 },
       );
     }
 
-    if (scenario || scenarioProps === "error2") {
+    if (scenario || scenarioProps === "E02") {
       return HttpResponse.json(
         { message: "유효하지 않은 이메일입니다." },
         { status: 400 },
       );
     }
 
-    if (scenario || scenarioProps === "error3") {
+    if (scenario || scenarioProps === "E03") {
       return HttpResponse.json(
         { message: "이메일 서버가 연결되지 않습니다." },
         { status: 500 },

--- a/src/mocks/handlers/room.ts
+++ b/src/mocks/handlers/room.ts
@@ -1,10 +1,14 @@
 import { BASE_URL, END_POINTS } from "@constants/api";
 import dummyRoomDetail from "@mocks/data/dummyRoomDetail.json";
+import dummyStock from "@mocks/data/dummyStock.json";
 import { http, HttpResponse } from "msw";
 
 const roomHandlers = [
   http.get(BASE_URL + END_POINTS.ROOM(":productId"), () => {
     return HttpResponse.json(dummyRoomDetail);
+  }),
+  http.get(BASE_URL + END_POINTS.STOCK, () => {
+    return HttpResponse.json(dummyStock);
   }),
 ];
 

--- a/src/mocks/handlers/room.ts
+++ b/src/mocks/handlers/room.ts
@@ -2,8 +2,10 @@ import { BASE_URL, END_POINTS } from "@constants/api";
 import dummyRoomDetail from "@mocks/data/dummyRoomDetail.json";
 import { http, HttpResponse } from "msw";
 
-export const roomHandlers = [
-  http.get(`${BASE_URL + END_POINTS.ROOM(":roomId")}`, () => {
+const roomHandlers = [
+  http.get(BASE_URL + END_POINTS.ROOM(":productId"), () => {
     return HttpResponse.json(dummyRoomDetail);
   }),
 ];
+
+export default roomHandlers;

--- a/src/mocks/handlers/yanoljaAccount.ts
+++ b/src/mocks/handlers/yanoljaAccount.ts
@@ -1,0 +1,34 @@
+import { BASE_URL, END_POINTS } from "@constants/api";
+import { http, HttpResponse } from "msw";
+
+export const getYanoljaAccount = (scenarioProps?: string) => {
+  return http.post(BASE_URL + END_POINTS.YANOLJA, () => {
+    const pageParams = new URLSearchParams(window.location.search);
+    const scenario = pageParams.get("scenario");
+
+    if (scenario || scenarioProps === "A01") {
+      return HttpResponse.json(
+        { message: "야놀자 계정을 찾을 수 없습니다." },
+        { status: 404 },
+      );
+    }
+
+    if (scenario || scenarioProps === "A02") {
+      return HttpResponse.json(
+        { message: "공백이 없어야 합니다." },
+        { status: 400 },
+      );
+    }
+
+    if (scenario || scenarioProps === "A03") {
+      return HttpResponse.json(
+        { message: "유효하지 않은 이메일입니다." },
+        { status: 400 },
+      );
+    }
+  });
+};
+
+const yanoljaAccountHandlers = [getYanoljaAccount()];
+
+export default yanoljaAccountHandlers;

--- a/src/pages/homePage/itemCarousel/itemCarouselUnit/ItemCarouselUnit.tsx
+++ b/src/pages/homePage/itemCarousel/itemCarouselUnit/ItemCarouselUnit.tsx
@@ -24,7 +24,7 @@ const ItemCarouselUnit = ({ item }: UnitProps) => {
     : "";
 
   const onClickHandler = (num: number) => {
-    navigate(PATH.DETAIL_ROOM + "/" + hotel[num].id);
+    navigate(PATH.DETAIL_ROOM(hotel[num].id));
   };
 
   return (

--- a/src/pages/homePage/weekendCarousel/weekendCarouselUnit/WeekendUnit.tsx
+++ b/src/pages/homePage/weekendCarousel/weekendCarouselUnit/WeekendUnit.tsx
@@ -16,7 +16,7 @@ const WeekendUnit = ({ item }: UnitProps) => {
   const CHKOUT = format(parseISO(item[1].checkOutDate), "MM.dd");
 
   const onClickHandler = () => {
-    navigate(PATH.DETAIL_ROOM + "/" + item[1].id);
+    navigate(PATH.DETAIL_ROOM(item[1].id));
   };
 
   return (

--- a/src/pages/roomDetailPage/RoomDetail.tsx
+++ b/src/pages/roomDetailPage/RoomDetail.tsx
@@ -11,10 +11,11 @@ import * as S from "./RoomDetail.style";
 import { useEffect } from "react";
 
 const RoomDetail = () => {
-  const { roomId } = useParams();
-  if (!roomId) throw new Error("존재하지 않는 roomId 입니다.");
+  const { productId } = useParams();
 
-  const { data } = useRoomQuery(roomId);
+  if (!productId) throw new Error("존재하지 않는 roomId 입니다.");
+
+  const { data } = useRoomQuery(productId);
   const { rawData, discountRate } = data;
 
   const { handleToast } = useToastConfig();
@@ -38,7 +39,7 @@ const RoomDetail = () => {
         draggable={true}
       />
       <RoomInfo room={rawData} discount={discountRate} />
-      <RoomNavBar room={rawData} discount={discountRate} roomId={roomId} />
+      <RoomNavBar room={rawData} discount={discountRate} roomId={productId} />
     </S.Container>
   );
 };

--- a/src/pages/roomDetailPage/components/roomNavBar/RoomNavBar.tsx
+++ b/src/pages/roomDetailPage/components/roomNavBar/RoomNavBar.tsx
@@ -4,6 +4,7 @@ import { PATH } from "@constants/path";
 import useToastConfig from "@hooks/common/useToastConfig";
 
 import * as S from "./RoomNavBar.style";
+import { useStockQuery } from "@hooks/api/useStockQuery";
 
 interface RoomNavBarProps {
   room: RoomNavBarData;
@@ -14,8 +15,9 @@ interface RoomNavBarProps {
 const RoomNavBar = ({ room, roomId, discount }: RoomNavBarProps) => {
   const navigate = useNavigate();
   const { handleToast } = useToastConfig();
+  const { refetch } = useStockQuery(roomId);
 
-  const handlePurchaseClick = () => {
+  const handlePurchaseClick = async () => {
     if (room.isSeller) {
       handleToast(true, [<>내가 판매하는 상품은 구매가 불가합니다</>]);
       return;
@@ -23,7 +25,12 @@ const RoomNavBar = ({ room, roomId, discount }: RoomNavBarProps) => {
       return;
     }
 
-    navigate(PATH.PAYMENT(roomId));
+    const stockData = await refetch();
+    if (stockData?.data?.hasStock) {
+      navigate(PATH.PAYMENT(roomId));
+    } else {
+      handleToast(true, [<>이미 판매완료된 상품입니다</>]);
+    }
   };
 
   return (

--- a/src/pages/searchPage/components/searchItem/SearchItem.tsx
+++ b/src/pages/searchPage/components/searchItem/SearchItem.tsx
@@ -21,7 +21,7 @@ const SearchItem = ({ item }: { item: ISearchList }) => {
     return formattedDate;
   };
   const handleClickItem = () => {
-    navigate(`${PATH.DETAIL_ROOM}/${item.id}`);
+    navigate(PATH.DETAIL_ROOM(item.id));
   };
   return (
     <>

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -17,7 +17,6 @@ import RoomDetail from "@pages/roomDetailPage/RoomDetail";
 import TransferPurchase from "@/pages/transferPurchasePage/TransferPurchase";
 import TransferSale from "@pages/transferSalePage/TransferSale";
 import TransferWriting from "@/pages/transferWritingPage/TransferWriting";
-
 import ManageAccount from "@/pages/myPage/manage/manageAccount/ManageAccount";
 import ManageProfile from "@/pages/myPage/manage/manageProfile/ManageProfile";
 import Setting from "@/pages/myPage/setting/Setting";

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -114,10 +114,10 @@ export const router = createBrowserRouter([
         ),
       },
       {
-        path: PATH.DETAIL_ROOM + "/:roomId",
+        path: PATH.DETAIL_ROOM(":productId"),
         element: (
           <LocalErrorBoundary>
-            <Suspense fallback={<div>LOADING</div>}>
+            <Suspense fallback={<Loading />}>
               <RoomDetail />
             </Suspense>
           </LocalErrorBoundary>
@@ -190,7 +190,7 @@ export const router = createBrowserRouter([
         element: (
           <LocalErrorBoundary>
             <Suspense fallback={<Loading />}>
-              <Outlet />
+              <Payment />
             </Suspense>
           </LocalErrorBoundary>
         ),

--- a/src/types/payment.ts
+++ b/src/types/payment.ts
@@ -1,3 +1,7 @@
+export interface StockData {
+  hasStock: boolean;
+}
+
 export interface PaymentData {
   hotelImage: string;
   hotelName: string;


### PR DESCRIPTION
### Issue Number

close #155 

### ⛳️ Task

- [x] 화이팅하기
- [x] 결제 페이지 조회 전에 재고확인을 하고, 재고가 없으면 알럿 메시지를 띄우는 로직을 추가했습니다!
- [x] 상세페이지 PATH 수정

제가 리베이스를 잘못해서 이전 커밋까지 같이 올라갔네요 😭 다음부턴 조심하겠습니다ㅠㅠ

### ✍️ Note

#### 상세페이지 PATH 수정
```
 DETAIL_ROOM: (productId: string | number) => `/room/${productId}`,
```

### 📸 Screenshot

### 📎 Reference
