### PR TITLE
[#205] 모바일에서 터치 안되는 이슈 해결, 이벤트 버블링 막기

### DIFF
--- a/src/hooks/common/useAnimateCarousel.ts
+++ b/src/hooks/common/useAnimateCarousel.ts
@@ -73,7 +73,6 @@ export const useAnimateCarousel = ({
     };
 
     const handleTouchEnd = (moveEvent: globalThis.TouchEvent) => {
-      if (moveEvent.cancelable) moveEvent.preventDefault();
       const delta =
         moveEvent.changedTouches[0].pageX - touchEvent.changedTouches[0].pageX;
       handleDragEnd(delta);

--- a/src/pages/homePage/itemCarousel/itemCarouselUnit/ItemCarouselUnit.tsx
+++ b/src/pages/homePage/itemCarousel/itemCarouselUnit/ItemCarouselUnit.tsx
@@ -23,24 +23,28 @@ const ItemCarouselUnit = ({ item }: UnitProps) => {
     ? format(parseISO(hotel[1].checkOutDate), "MM.dd")
     : "";
 
-  const onClickHandler = (num: number) => {
-    navigate(PATH.DETAIL_ROOM(hotel[num].id));
+  const onClickHandler = (
+    number: number,
+    e: React.MouseEvent<Element, MouseEvent>,
+  ) => {
+    e.stopPropagation();
+    navigate(PATH.DETAIL_ROOM(hotel[number].id));
   };
 
   return (
     <S.LocaleWrapper $display={hotel ? "block" : "none"}>
       {hotel[0] && (
-        <S.ItemUnit onClick={() => onClickHandler(0)}>
-          <img src={hotel[0].imageUrl} onClick={() => onClickHandler(0)} />
+        <S.ItemUnit onClick={(e) => onClickHandler(0, e)}>
+          <img src={hotel[0].imageUrl} />
           <div className="item-info">
             <div className="hotel_title">
-              <h1 onClick={() => onClickHandler(0)}>{hotel[0].hotelName}</h1>
-              <h3 onClick={() => onClickHandler(0)}>{hotel[0].roomType}</h3>
+              <h1>{hotel[0].hotelName}</h1>
+              <h3>{hotel[0].roomType}</h3>
               <S.Sticker>
                 {CHKIN1} ~ {CHKOUT1}
               </S.Sticker>
             </div>
-            <div className="hotel_price" onClick={() => onClickHandler(0)}>
+            <div className="hotel_price">
               <h5>{hotel[0].originalPrice} 원</h5>
               <h1>
                 {priceFormat(hotel[0].salePrice)} 원
@@ -51,17 +55,17 @@ const ItemCarouselUnit = ({ item }: UnitProps) => {
         </S.ItemUnit>
       )}
       {hotel[1] && (
-        <S.ItemUnit onClick={() => onClickHandler(1)}>
-          <img src={hotel[1].imageUrl} onClick={() => onClickHandler(0)} />
+        <S.ItemUnit onClick={(e) => onClickHandler(1, e)}>
+          <img src={hotel[1].imageUrl} />
           <div className="item-info">
             <div className="hotel_title">
-              <h1 onClick={() => onClickHandler(0)}>{hotel[1].hotelName}</h1>
-              <h3 onClick={() => onClickHandler(0)}>{hotel[1].roomType}</h3>
+              <h1>{hotel[1].hotelName}</h1>
+              <h3>{hotel[1].roomType}</h3>
               <S.Sticker>
                 {CHKIN0} ~ {CHKOUT0}
               </S.Sticker>
             </div>
-            <div className="hotel_price" onClick={() => onClickHandler(0)}>
+            <div className="hotel_price">
               <h5>{hotel[1].originalPrice} 원</h5>
               <h1>
                 {priceFormat(hotel[1].salePrice)} 원


### PR DESCRIPTION
### Issue Number

close #205

### ⛳️ Task

- [x] 화이팅하기
- [x] 모바일에서 터치 안되는 이슈 
- [x] 메인캐러셀 아이템 onClick 이벤트 버블링되는 현상

### ✍️ Note

#### 모바일에서 터치 안되는 이슈 

useAnimateCarousel 훅에서 터치이벤트 기본동작 막고 있던걸 제거했습니다!
```if (moveEvent.cancelable) moveEvent.preventDefault();``` 

저걸 추가했던게 터치이벤트를 사용하면 무조건 마우스이벤트도 발생시켜서 제가 터치이벤트의 기본동작을 막았엇거든용.. 그래서 모바일에서 터치이벤트가 발생안된 것 같아요!

### 📸 Screenshot

### 📎 Reference
