### PR TITLE
[#257] 알림 허용 안 할 시 fcm토큰 발급 요청 안되도록 수정

### DIFF
--- a/src/apis/fetchLogin.ts
+++ b/src/apis/fetchLogin.ts
@@ -7,7 +7,7 @@ import { axiosInstance } from "./axiosInstance";
 interface LoginProps {
   email: string;
   password: string;
-  fcmToken: string;
+  fcmToken?: string;
 }
 
 export const postLogin = async ({

--- a/src/firebase.ts
+++ b/src/firebase.ts
@@ -1,4 +1,5 @@
 import { initializeApp } from "firebase/app";
+import { getMessaging } from "firebase/messaging";
 
 // firebase
 const firebaseConfig = {
@@ -12,6 +13,7 @@ const firebaseConfig = {
 };
 
 export const app = initializeApp(firebaseConfig);
+export const messaging = getMessaging(app);
 
 // Get registration token. Initially this makes a network call, once retrieved
 // subsequent calls to getToken will return from cache.

--- a/src/pages/signInPage/SignIn.tsx
+++ b/src/pages/signInPage/SignIn.tsx
@@ -5,8 +5,7 @@ import useToastConfig from "@hooks/common/useToastConfig";
 import { PATH } from "@constants/path";
 import { useUserInfoStore } from "@/store/store";
 import { postLogin } from "@apis/fetchLogin";
-import { getMessaging, getToken } from "firebase/messaging";
-import { app } from "@/firebase";
+import getNotificationPermission from "@/utils/getNotificationPermission";
 
 type FormValues = {
   email: string;
@@ -33,11 +32,7 @@ const SignIn = () => {
   const handleOnSubmit = async (data: FormValues) => {
     const { email, password } = data;
 
-    const messaging = getMessaging(app);
-
-    const fcmToken = await getToken(messaging, {
-      vapidKey: import.meta.env.VITE_FIREBASE_VAPID,
-    });
+    const fcmToken = await getNotificationPermission();
 
     await postLogin({ email, password, fcmToken })
       .then((loginData) => {

--- a/src/utils/getNotificationPermission.ts
+++ b/src/utils/getNotificationPermission.ts
@@ -1,0 +1,29 @@
+import { messaging } from "@/firebase";
+import { getToken, onMessage } from "firebase/messaging";
+
+async function getNotificationPermission() {
+  console.log("권한 요청 중...");
+
+  const permission = await Notification.requestPermission();
+  if (permission === "denied") {
+    console.log("알림 권한 허용 안됨");
+    return;
+  }
+
+  console.log("알림 권한이 허용됨");
+
+  const fcmToken = await getToken(messaging, {
+    vapidKey: import.meta.env.VITE_FIREBASE_VAPID,
+  });
+
+  if (fcmToken) console.log("token: ", fcmToken);
+  else console.log("Can not get Token");
+
+  onMessage(messaging, (payload) => {
+    console.log("메시지가 도착했습니다.", payload);
+  });
+
+  return fcmToken;
+}
+
+export default getNotificationPermission;


### PR DESCRIPTION
### Issue Number

close #257

### ⛳️ Task

- [x] 화이팅하기
- [x] 알림 허용 안 할 시 fcm토큰 발급 요청 안되도록 수정

### ✍️ Note

이게 모바일 브라우저에서 로그인 안되는 것과 연관 있는 듯 하여 수정했습니다.

### 📸 Screenshot

### 📎 Reference
