### PR TITLE
[#246] 바텀네비 툴팁 추가

### DIFF
--- a/src/components/layout/navBottom/NavBottom.tsx
+++ b/src/components/layout/navBottom/NavBottom.tsx
@@ -2,9 +2,12 @@ import { PATH } from "@/constants/path";
 import { useLocation } from "react-router-dom";
 import * as S from "./NavBottom.style";
 import { isMobile } from "@/utils/isMobile";
+import { useState } from "react";
+import ToolTip from "./toolTip/ToolTip";
 
 const BottomNav = () => {
   const isMobileDevice = isMobile();
+  const [isToolTipOn, setIsToolTipOn] = useState(true);
 
   const { pathname } = useLocation();
   const navList = [
@@ -36,6 +39,9 @@ const BottomNav = () => {
 
   return (
     <S.BottomNavContainer $isMobile={isMobileDevice}>
+      {isToolTipOn && (
+        <ToolTip onClickClose={setIsToolTipOn}>숙박권을 판매해보세요.</ToolTip>
+      )}
       <S.BottomNavWrapper>
         {navList.map((item) => {
           return (

--- a/src/components/layout/navBottom/toolTip/ToolTip.style.ts
+++ b/src/components/layout/navBottom/toolTip/ToolTip.style.ts
@@ -1,0 +1,53 @@
+import styled from "styled-components";
+import { IoIosClose } from "react-icons/io";
+
+export const Container = styled.div`
+  position: absolute;
+  width: 160px;
+  height: 32px;
+
+  top: -34px;
+  left: calc(37.5% - 80px);
+  border-radius: 16px;
+
+  background-color: ${({ theme }) => theme.color.black};
+
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  z-index: 10;
+`;
+
+export const Wrapper = styled.section`
+  width: 160px;
+  height: 32px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0 10px 0 16px;
+`;
+
+export const TextArea = styled.span`
+  color: ${({ theme }) => theme.color.percentOrange};
+  ${({ theme }) => theme.typo.caption2};
+  flex-shrink: 0;
+  transform: translateY(0.3px);
+`;
+
+export const CloseButton = styled(IoIosClose)`
+  font-size: 24px;
+  color: white;
+  cursor: pointer;
+`;
+
+export const Tail = styled.div`
+  position: absolute;
+  top: 10px;
+  transform: rotate(45deg);
+  width: 24px;
+  height: 24px;
+  background-color: ${({ theme }) => theme.color.black};
+  z-index: -1;
+  box-shadow: 0px 4px 8px rgba(0, 0, 0, 0.2);
+`;

--- a/src/components/layout/navBottom/toolTip/ToolTip.tsx
+++ b/src/components/layout/navBottom/toolTip/ToolTip.tsx
@@ -1,0 +1,21 @@
+import { ReactNode } from "react";
+import * as S from "./ToolTip.style";
+
+interface ToolTipProps {
+  children: ReactNode;
+  onClickClose: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+const ToolTip = ({ children, onClickClose }: ToolTipProps) => {
+  return (
+    <S.Container>
+      <S.Tail />
+      <S.Wrapper>
+        <S.TextArea>{children}</S.TextArea>
+        <S.CloseButton onClick={() => onClickClose(false)} />
+      </S.Wrapper>
+    </S.Container>
+  );
+};
+
+export default ToolTip;


### PR DESCRIPTION
### Issue Number

close https://github.com/SCBJ-7/SCBJ-FE/issues/246

### ⛳️ Task

- [x] 화이팅하기
- [x] 툴팁 만들기

### ✍️ Note

### 📸 Screenshot

<img width="864" alt="image" src="https://github.com/SCBJ-7/SCBJ-FE/assets/126222848/fa710689-9a88-4e60-9760-68416b3c635b">



위치는
position: absolute;
left: calc(37.5% - (툴팁 width / 2));
로 해서 맞췄습니다!

툴팁을 끈다음 언제 켜지는지는 잘 몰라서 일단 제일 간단한 useState로 만들었습니다.
바텀 네비는 세션 내내 거의 같이 가기 때문에 한 번 끄면 그 세션동안 유지된다고 보시면 됩니당..
바텀네비 없는 페이지 갔다가 들어오면 다시 켜지긴 할거같습니다.

아주 사소한 정보이니 로컬스토리지로 저장할까도 생각해봤는데 아이폰 사파리에서 로컬스토리지 잘 안먹히는 이슈가 있더라구요.
그래서 일단 간단한 방법으로 해봤습니다.

### 📎 Reference
