### PR TITLE
[#188] 결제 페이지 QA 및 에러 해결

### DIFF
--- a/src/components/modal/Modal.style.ts
+++ b/src/components/modal/Modal.style.ts
@@ -21,6 +21,7 @@ export const ModalContent = styled.div`
   box-shadow: 0 4px 30px rgba(0, 0, 0, 0.1);
   transform: translateY(-50%);
   top: -50%;
+  border-radius: 12px;
 
   & > p {
     padding: 1rem;
@@ -35,6 +36,14 @@ export const ModalContent = styled.div`
     padding: 10px 20px;
     ${({ theme }) => theme.typo.button4};
     cursor: pointer;
+
+    -webkit-border-bottom-right-radius: 12px;
+    -webkit-border-bottom-left-radius: 12px;
+    -moz-border-radius-bottomright: 12px;
+    -moz-border-radius-bottomleft: 12px;
+    border-bottom-right-radius: 12px;
+    border-bottom-left-radius: 12px;
+
     &:hover {
       background-color: ${({ theme }) => theme.color.darkOrange};
     }

--- a/src/hooks/api/usePaymentQuery.ts
+++ b/src/hooks/api/usePaymentQuery.ts
@@ -11,6 +11,10 @@ export const usePaymentQuery = (productId: string) => {
   const paymentQuery = useSuspenseQuery<PaymentData>({
     queryKey: ["payment", productId],
     queryFn: async () => await getPayment(productId),
+    staleTime: 5 * 60 * 1000,
+    gcTime: 60 * 1000,
+    refetchOnWindowFocus: true,
+    refetchOnReconnect: true,
   });
 
   return paymentQuery;
@@ -28,7 +32,10 @@ export const usePaymentSuccessQuery = ({
   const paymentSuccessQuery = useQuery({
     queryKey: ["payment"],
     queryFn: async () => await getPaymentSuccess({ paymentType, pgToken }),
-    enabled: false,
+    enabled: !!pgToken,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
+    refetchInterval: false,
   });
 
   return paymentSuccessQuery;

--- a/src/pages/paymentPage/Payment.tsx
+++ b/src/pages/paymentPage/Payment.tsx
@@ -18,6 +18,7 @@ import { useEffect, useState } from "react";
 import { isAxiosError } from "axios";
 import { paymentCaptions } from "@constants/caption";
 import { ERROR_CODE } from "@/constants/api";
+import { PATH } from "@/constants/path";
 
 interface PaymentProps {
   action: "default" | "cancel" | "ready";
@@ -66,7 +67,9 @@ const Payment = ({ action }: PaymentProps) => {
 
   useEffect(() => {
     if (isSuccess) {
-      navigate(`/payment/${successData.paymentHistoryId}/success`);
+      navigate(PATH.PAYMENT_SUCCESS(successData.paymentHistoryId), {
+        replace: true,
+      });
     }
 
     if (isError && isAxiosError(error)) {

--- a/src/pages/paymentPage/components/userInfoSection/UserInfoSection.tsx
+++ b/src/pages/paymentPage/components/userInfoSection/UserInfoSection.tsx
@@ -1,6 +1,6 @@
 import * as S from "./UserInfoSection.style";
 import Checkbox from "@components/checkbox/Checkbox";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useLoadUserInfo } from "@hooks/common/useLoadUserInfo";
 import { Controller, useFormContext } from "react-hook-form";
 import { EMAIL_REGEX, PHONE_NUMBER_REGEX } from "@constants/regex";
@@ -11,8 +11,11 @@ const UserInfoSection = () => {
     register,
     watch,
     setValue,
+    resetField,
     formState: { errors },
   } = useFormContext();
+
+  const [userEdited, setUserEdited] = useState(false);
 
   const isDiffUser = watch("isDiffUser");
 
@@ -29,7 +32,18 @@ const UserInfoSection = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isDiffUser, setValue, userInfo]);
 
+  const handleCheckboxChange = (checked: boolean) => {
+    if (!userEdited) {
+      resetField("name");
+      resetField("email");
+      resetField("phone");
+    }
+    setUserEdited(false);
+    setValue("isDiffUser", checked);
+  };
+
   const handleFieldChange = () => {
+    if (!userEdited) setUserEdited(true);
     setValue("isDiffUser", false);
   };
 
@@ -43,7 +57,7 @@ const UserInfoSection = () => {
           <Checkbox
             id="isDiffUser"
             isChecked={field.value}
-            onChange={field.onChange}
+            onChange={(e) => handleCheckboxChange(e.target.checked)}
             variant="caption"
             ariaLabel="구매자 정보와 동일합니다."
           >


### PR DESCRIPTION
### Issue Number

close #188

### ⛳️ Task

- [x] 결제 완료시 조회 api 수정
- [x] 결제 취소 시 모달창 띄우기
- [x]  체크인/체크아웃 부분 왼쪽정렬
- [x] 구매자 정보와 동일합니다를 클릭하면 번호,이름, 이메일을 바꾸면  체크박스 풀림
- [x] 체크 해제하면 폼 리셋하기 (직접 체크해제했을 때와 구분 필요)
- [x] 모달 컴포넌트 ui 수정
- [x] 결제 요청 다시 리패치 되지 않도록 수정
- [x] 결제 완료시 결제완료페이지로 히스토리 대체하기
- [x] 결제 중 에러 시 무한 요청감

### ✍️ Note

### 📸 Screenshot

### 📎 Reference
