### PR TITLE
[#271] 모바일 사파리일 경우 예외처리

### DIFF
--- a/src/apis/logout.ts
+++ b/src/apis/logout.ts
@@ -1,9 +1,13 @@
 import { axiosInstance } from "@apis/axiosInstance";
 import { ACCESS_TOKEN, END_POINTS, REFRESH_TOKEN } from "@/constants/api";
+import getNotificationPermission from "@/utils/getNotificationPermission";
 
 export const logout = async () => {
+  const fcmToken = getNotificationPermission();
+
   await axiosInstance.post(`${END_POINTS.USER_INFO}/logout`, {
     accessToken: localStorage.getItem(ACCESS_TOKEN),
     refreshToken: localStorage.getItem(REFRESH_TOKEN),
+    fcmToken,
   });
 };

--- a/src/firebase.ts
+++ b/src/firebase.ts
@@ -1,5 +1,6 @@
 import { initializeApp } from "firebase/app";
 import { getMessaging } from "firebase/messaging";
+import { isMobileSafari } from "./utils/isMobileSafari";
 
 // firebase
 const firebaseConfig = {
@@ -13,7 +14,7 @@ const firebaseConfig = {
 };
 
 export const app = initializeApp(firebaseConfig);
-export const messaging = getMessaging(app);
+export const messaging = !isMobileSafari() && getMessaging(app);
 
 // Get registration token. Initially this makes a network call, once retrieved
 // subsequent calls to getToken will return from cache.

--- a/src/firebase.ts
+++ b/src/firebase.ts
@@ -1,6 +1,8 @@
 import { initializeApp } from "firebase/app";
 import { getMessaging } from "firebase/messaging";
 import { isMobileSafari } from "./utils/isMobileSafari";
+import { isAccessTokenExpired } from "./utils/checkToken";
+import getNotificationPermission from "./utils/getNotificationPermission";
 
 // firebase
 const firebaseConfig = {
@@ -15,6 +17,13 @@ const firebaseConfig = {
 
 export const app = initializeApp(firebaseConfig);
 export const messaging = !isMobileSafari() && getMessaging(app);
+
+// isLoggedIn wrapper로 만든걸 사용하고 싶었는데 만료 여부도 확인해야돼서 localStorage.getItem을 썼습니다!
+const accessToken = localStorage.getItem("accessToken");
+if (accessToken && isAccessTokenExpired(accessToken)) {
+  await getNotificationPermission();
+  // 로그인을 안 하더라도 로컬 스토리지의 accessToken이 만료되지 않았다면 getNotification을 실행
+}
 
 // Get registration token. Initially this makes a network call, once retrieved
 // subsequent calls to getToken will return from cache.

--- a/src/pages/alarmPage/AlarmPage.tsx
+++ b/src/pages/alarmPage/AlarmPage.tsx
@@ -6,8 +6,11 @@ import { fetchUserInfo } from "@apis/fetchUserInfo";
 import NoResult from "@components/noResult/NoResult";
 import { PATH } from "@constants/path";
 import Loading from "@/components/lottie/loading/Loading";
+import { isMobileSafari } from "@/utils/isMobileSafari";
 
 const AlarmPage = () => {
+  const mobileSafari = isMobileSafari();
+
   const { data: userData } = useSuspenseQuery({
     queryKey: ["UserInfo"],
     queryFn: fetchUserInfo,
@@ -16,41 +19,54 @@ const AlarmPage = () => {
   const { data: alarmData, isLoading } = useQuery({
     queryKey: ["alarm", userData?.id],
     queryFn: fetchAlarm,
-    enabled: !!userData?.id,
+    enabled: !!userData?.id && !mobileSafari,
   });
 
   if (isLoading) {
     return <Loading />;
   }
 
-  return (
-    <S.Container>
-      {alarmData?.map((item) =>
-        item.isRead ? (
-          <S.OldMessage key={item.id}>
-            <h1>{item.content}</h1>
-            <h3>{format(parseISO(item.date), "yyyy. MM. dd. HH:mm")}</h3>
-          </S.OldMessage>
-        ) : (
-          <S.NewMessage key={item.id}>
-            <h1>{item.content}</h1>
-            <div>
-              {!item.isRead && <section />}
+  if (mobileSafari) {
+    return (
+      <NoResult
+        title="알림을 사용할 수 없는 브라우저입니다"
+        desc="모바일 사파리 브라우저에서 알림을 사용할 수 없어요"
+        buttonDesc="홈 화면으로 돌아가기"
+        navigateTo={PATH.ROOT}
+      />
+    );
+  }
+
+  if (alarmData) {
+    return (
+      <S.Container>
+        {alarmData?.map((item) =>
+          item.isRead ? (
+            <S.OldMessage key={item.id}>
+              <h1>{item.content}</h1>
               <h3>{format(parseISO(item.date), "yyyy. MM. dd. HH:mm")}</h3>
-            </div>
-          </S.NewMessage>
-        ),
-      )}
-      {alarmData && alarmData.length === 0 && (
-        <NoResult
-          title="알림 내역이 없습니다."
-          desc="판매가 이루어지면 알림을 확인하실수 있어요."
-          buttonDesc="돌아가기"
-          navigateTo={PATH.ROOT}
-        />
-      )}
-    </S.Container>
-  );
+            </S.OldMessage>
+          ) : (
+            <S.NewMessage key={item.id}>
+              <h1>{item.content}</h1>
+              <div>
+                {!item.isRead && <section />}
+                <h3>{format(parseISO(item.date), "yyyy. MM. dd. HH:mm")}</h3>
+              </div>
+            </S.NewMessage>
+          ),
+        )}
+        {alarmData && alarmData.length === 0 && (
+          <NoResult
+            title="알림 내역이 없습니다."
+            desc="판매가 이루어지면 알림을 확인하실수 있어요."
+            buttonDesc="돌아가기"
+            navigateTo={PATH.ROOT}
+          />
+        )}
+      </S.Container>
+    );
+  }
 };
 
 export default AlarmPage;

--- a/src/pages/signInPage/SignIn.tsx
+++ b/src/pages/signInPage/SignIn.tsx
@@ -32,12 +32,7 @@ const SignIn = () => {
   const handleOnSubmit = async (data: FormValues) => {
     const { email, password } = data;
 
-    let fcmToken;
-    try {
-      fcmToken = await getNotificationPermission();
-    } catch {
-      fcmToken = undefined;
-    }
+    const fcmToken = await getNotificationPermission();
     await postLogin({ email, password, fcmToken })
       .then((loginData) => {
         const { memberResponse, tokenResponse } = loginData;

--- a/src/pages/signInPage/SignIn.tsx
+++ b/src/pages/signInPage/SignIn.tsx
@@ -32,8 +32,12 @@ const SignIn = () => {
   const handleOnSubmit = async (data: FormValues) => {
     const { email, password } = data;
 
-    const fcmToken = await getNotificationPermission();
-
+    let fcmToken;
+    try {
+      fcmToken = await getNotificationPermission();
+    } catch {
+      fcmToken = undefined;
+    }
     await postLogin({ email, password, fcmToken })
       .then((loginData) => {
         const { memberResponse, tokenResponse } = loginData;

--- a/src/utils/getNotificationPermission.ts
+++ b/src/utils/getNotificationPermission.ts
@@ -3,6 +3,9 @@ import { getToken, onMessage } from "firebase/messaging";
 
 async function getNotificationPermission() {
   console.log("권한 요청 중...");
+  // isMobileSafari일 경우 false일 가능성이 생김.
+  // messaging이 false일 경우 return
+  if (!messaging) return;
 
   const permission = await Notification.requestPermission();
   if (permission === "denied") {

--- a/src/utils/isMobileSafari.ts
+++ b/src/utils/isMobileSafari.ts
@@ -1,0 +1,6 @@
+export const isMobileSafari = () => {
+  const userAgent = navigator.userAgent;
+  const isMobileSafari =
+    /iPhone|iPad|iPod/i.test(userAgent) && /AppleWebKit/i.test(userAgent);
+  return isMobileSafari;
+};


### PR DESCRIPTION
### Issue Number

close https://github.com/SCBJ-7/SCBJ-FE/issues/271

### ⛳️ Task

- [x] 화이팅하기
- [x] 모바일 사파리일 경우 fcm messaging 초기화 x
- [x] getNotification 함수에서 messaging이 false일 경우(모바일 사파리일 경우) early return
- [x] 로그아웃 시 fcm 토큰 전달

나영님께서 모바일 사파리일 경우 fcm messaging 초기화가 에러가 걸려서 로그인이 진행 안 된다는 것을 밝혀내셨습니다. (god..)

### ✍️ Note

## isMobileSafari 훅
사파리일 경우 true, 아닐 경우 false를 반환합니다.

```javascript
export const isMobileSafari = () => {
  const userAgent = navigator.userAgent;
  const isMobileSafari =
    /iPhone|iPad|iPod/i.test(userAgent) && /AppleWebKit/i.test(userAgent);
  return isMobileSafari;
};
```

## firebase.ts 초기화 시 모바일 사파리 예외처리
isMobileSafari가 false일때만 getMessaging을 초기화합니다. 
만약 사파리라면 false값이 됩니다.

```javascript
export const app = initializeApp(firebaseConfig);
export const messaging = !isMobileSafari() && getMessaging(app);
```

그리고 로그인을 안 하더라도 로컬 스토리지의 accessToken이 만료되지 않았으면 서버측에서는 계속 알림을 보내고 있을거 같습니다.
그래서 getNotificationPermission을 또 다시 실행시켜봤습니다. 실제로 효과가 있을지 약간 의문이어서 혹시 불필요해보인다면 가감없이 얘기해주세요!

```javascript
// isLoggedIn wrapper로 만든걸 사용하고 싶었는데 만료 여부도 확인해야돼서 실제 accessToken값을 썼습니다!
const accessToken = localStorage.getItem("accessToken");
if (accessToken && isAccessTokenExpired(accessToken)) {
  // 로그인을 안 하더라도 로컬 스토리지의 accessToken이 만료되지 않았다면 getNotification을 실행
  await getNotificationPermission();
}
```

## getNotificationPermission에서 모바일 사파리 예외처리
getNotificationPermission에서 messaging이 false이면 early return을 시킵니다.

```javascript
async function getNotificationPermission() {
  console.log("권한 요청 중...");
  // isMobileSafari일 경우 false일 가능성이 생김.
  // messaging이 false일 경우 return
  if (!messaging) return;
```

## 알림 페이지에서 모바일 사파리일 경우 useQuery enable되지 않게 설정, NoResult 컴포넌트 표출
```
const { data: alarmData, isLoading } = useQuery({
    queryKey: ["alarm", userData?.id],
    queryFn: fetchAlarm,
    enabled: !!userData?.id,
    enabled: !!userData?.id && !mobileSafari, // 모바일 사파리가 아니어야 enabled 됩니다
  });

  if (mobileSafari) {
    return (
      <NoResult
        title="알림을 사용할 수 없는 브라우저입니다"
        desc="모바일 사파리 브라우저에서 알림을 사용할 수 없어요"
        buttonDesc="홈 화면으로 돌아가기"
        navigateTo={PATH.ROOT}
      />
    );
  }
```

## 로그아웃 시에도 fcm token 전달

```javascript
export const logout = async () => {
  const fcmToken = getNotificationPermission();

  await axiosInstance.post(`${END_POINTS.USER_INFO}/logout`, {
    accessToken: localStorage.getItem(ACCESS_TOKEN),
    refreshToken: localStorage.getItem(REFRESH_TOKEN),
    fcmToken,
  });
};
```

### 📸 Screenshot

### 📎 Reference
