### PR TITLE
[#319] 판매글 작성 페이지 로직 커스텀 훅으로 정리

### DIFF
--- a/src/apis/fetchMainItems.ts
+++ b/src/apis/fetchMainItems.ts
@@ -14,10 +14,7 @@ export const fetchMainItem = async (): Promise<
       "?cityNames=서울&cityNames=강원&cityNames=부산&cityNames=제주&cityNames=경상&cityNames=전라",
   );
 
-  console.log(data);
-
   const { weekend, ...locale } = data.data;
-  console.log(locale, "locale");
   const temp = weekend.content.length ? weekend.content : [];
 
   return [locale, temp];

--- a/src/apis/logout.ts
+++ b/src/apis/logout.ts
@@ -1,5 +1,6 @@
-import { ACCESS_TOKEN, END_POINTS, REFRESH_TOKEN } from "@/constants/api";
 import { axiosInstance } from "@apis/axiosInstance";
+
+import { ACCESS_TOKEN, END_POINTS, REFRESH_TOKEN } from "@/constants/api";
 
 export const logout = async () => {
   await axiosInstance.post(`${END_POINTS.USER_INFO}/logout`, {

--- a/src/components/Helmet/Helmet.tsx
+++ b/src/components/Helmet/Helmet.tsx
@@ -1,5 +1,6 @@
-import { PATH } from "@/constants/path";
 import { Helmet } from "react-helmet-async";
+
+import { PATH } from "@/constants/path";
 
 export const HelmetTag = ({ text }: { text: string }) => {
   return (

--- a/src/hooks/api/usePostTransferItems.ts
+++ b/src/hooks/api/usePostTransferItems.ts
@@ -1,0 +1,68 @@
+import { useMutation } from "@tanstack/react-query";
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+
+import { postTransferItems } from "@/apis/postTransferItems";
+import { PATH } from "@/constants/path";
+import { useSelectedItemStore } from "@/store/store";
+import { ProfileData } from "@/types/profile";
+
+interface PostTransferItems {
+  firstPrice: string;
+  secondPrice: string;
+  downTimeAfter: string;
+  is2ndChecked: boolean;
+  opt1: boolean;
+  opt2: boolean;
+  opt3: boolean;
+  optFinal: boolean;
+  bank: string | null;
+  accountNumber: string | null;
+  userData: ProfileData;
+}
+const usePostTransferItems = ({
+  firstPrice,
+  secondPrice,
+  downTimeAfter,
+  is2ndChecked,
+  opt1,
+  opt2,
+  opt3,
+  optFinal,
+  bank,
+  accountNumber,
+  userData,
+}: PostTransferItems) => {
+  const selectedItem = useSelectedItemStore((state) => state.selectedItem);
+
+  // 처음 들어올 때 계좌가 있는지 여부.
+  const [firstlyNoAccount] = useState(userData?.accountNumber ? false : true);
+
+  const navigate = useNavigate();
+  const { mutate } = useMutation({
+    mutationFn: () =>
+      postTransferItems({
+        pathVariable: `${selectedItem.reservationId}`,
+        firstPrice: Number(firstPrice.split(",").join("")),
+        secondPrice: Number(secondPrice.split(",").join("")),
+        bank: bank as string,
+        accountNumber: accountNumber as string,
+        secondGrantPeriod: Number(downTimeAfter),
+        isRegistered: is2ndChecked,
+        standardTimeSellingPolicy: opt1,
+        totalAmountPolicy: opt2,
+        sellingModificationPolicy: opt3,
+        productAgreement: optFinal,
+      }),
+    onSuccess: () => {
+      alert("판매 게시물이 성공적으로 등록되었습니다!");
+      navigate(PATH.WRITE_TRANSFER_SUCCESS + "?FNA=" + `${firstlyNoAccount}`, {
+        state: { bank, accountNumber },
+      });
+    },
+  });
+
+  return { mutate };
+};
+
+export default usePostTransferItems;

--- a/src/hooks/common/useAnimateCarousel.ts
+++ b/src/hooks/common/useAnimateCarousel.ts
@@ -7,7 +7,7 @@ interface CarouselProps {
 }
 
 const inrange = (v: number, min: number, max: number) => {
-  // v는 current number?
+  // v는 델타x
   if (v < min) return min;
   if (v > max) return max;
   return v;
@@ -38,6 +38,7 @@ export const useAnimateCarousel = ({
 
   const handleDragChange = (deltaX: number) => {
     setTransX(inrange(deltaX, -slideWidth, slideWidth));
+    console.log(deltaX, "deltaX");
   };
 
   const handleDragEnd = (deltaX: number) => {
@@ -68,6 +69,7 @@ export const useAnimateCarousel = ({
     const handleTouchMove = (moveEvent: globalThis.TouchEvent) => {
       if (moveEvent.cancelable) moveEvent.preventDefault();
 
+      console.log(moveEvent.touches, "moveEvent.touches");
       const delta = moveEvent.touches[0].pageX - touchEvent.touches[0].pageX;
       handleDragChange(delta);
     };
@@ -94,6 +96,8 @@ export const useAnimateCarousel = ({
     clickEvent.preventDefault();
 
     const handleMouseMove = (moveEvent: MouseEvent) => {
+      console.log(moveEvent.pageX, "mouseEvent pageX");
+      console.log(clickEvent.pageX, "clickevent pageX");
       const deltaX = moveEvent.pageX - clickEvent.pageX;
       handleDragChange(deltaX);
     };

--- a/src/hooks/common/useChangePage.ts
+++ b/src/hooks/common/useChangePage.ts
@@ -1,0 +1,55 @@
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+
+import { PATH } from "@/constants/path";
+import { useSelectedItemStore, useStateHeaderStore } from "@/store/store";
+
+interface changePageProps {
+  is2ndChecked: boolean;
+  firstCheckRef: React.MutableRefObject<null>;
+}
+
+const useChangePage = ({ is2ndChecked, firstCheckRef }: changePageProps) => {
+  const navigate = useNavigate();
+  const setHeaderConfig = useStateHeaderStore((state) => state.setHeaderConfig);
+  const selectedItem = useSelectedItemStore((state) => state.selectedItem);
+
+  // 현재 페이지가 어디인지
+  const [accountSetting, setAccountSetting] = useState<"none" | "enter">(
+    "none",
+  );
+
+  // 페이지 전환 시 적용할 효과
+  useEffect(() => {
+    if (accountSetting === "none") {
+      setHeaderConfig({
+        title: selectedItem.hotelName,
+        undo: () => {
+          navigate(PATH.WRITE_TRANSFER);
+        },
+      });
+
+      if (is2ndChecked && firstCheckRef.current) {
+        (firstCheckRef.current as HTMLInputElement).checked = true;
+      }
+    }
+
+    if (accountSetting === "enter") {
+      setHeaderConfig({
+        title: "계좌 연동하기",
+        undo: () => {
+          setAccountSetting("none");
+        },
+      });
+
+      if (is2ndChecked && firstCheckRef.current) {
+        (firstCheckRef.current as HTMLInputElement).checked = false;
+      }
+    }
+    // eslint-disable-next-line
+  }, [accountSetting]);
+
+  return { accountSetting, setAccountSetting };
+};
+
+export default useChangePage;

--- a/src/hooks/common/useReadyToSubmit.ts
+++ b/src/hooks/common/useReadyToSubmit.ts
@@ -1,0 +1,79 @@
+import { useEffect } from "react";
+
+import { ProfileData } from "@/types/profile";
+
+interface ReadyToSubmitProps {
+  setReadyToSubmit: React.Dispatch<React.SetStateAction<boolean>>;
+  firstPrice: string;
+  secondPrice: string;
+  opt1: boolean;
+  opt2: boolean;
+  opt3: boolean;
+  optFinal: boolean;
+  bank: string | null;
+  accountNumber: string | null;
+  is2ndChecked: boolean;
+  downTimeAfter: string;
+  userData: ProfileData;
+}
+
+const useReadyToSubmit = ({
+  setReadyToSubmit,
+  firstPrice,
+  opt1,
+  opt2,
+  opt3,
+  optFinal,
+  bank,
+  accountNumber,
+  is2ndChecked,
+  secondPrice,
+  downTimeAfter,
+  userData,
+}: ReadyToSubmitProps) => {
+  useEffect(() => {
+    setReadyToSubmit(() => {
+      if (
+        firstPrice &&
+        opt1 &&
+        opt2 &&
+        opt3 &&
+        optFinal &&
+        bank &&
+        accountNumber
+      ) {
+        // accountNumber 추가
+        if (!is2ndChecked) return true; // 2차 가격 설정하기 체크 안 하고 계좌 등록된 경우
+
+        if (is2ndChecked && secondPrice && downTimeAfter) {
+          return true; // 2차 가격 설정한 경우
+        } else if (is2ndChecked && !secondPrice && !downTimeAfter) {
+          return false; // 2차 가격 체크했지만 아무것도 쓰지 않은 경우는 일단 가능
+        } else if (is2ndChecked && !secondPrice && downTimeAfter) {
+          return false; // 2차 가격 체크하고 2차 가격 입력 안 하고 시간만 입력한 경우
+        } else if (is2ndChecked && secondPrice && !downTimeAfter) {
+          return false; // 2차 가격 체크하고 2차 시간 입력 안 하고 가격만 입력한 경우
+        } else if (!userData?.bank || !userData?.accountNumber) {
+          return false;
+        }
+      }
+
+      return false; // 1차가격 설정과 약관 동의 안한 경우
+    });
+  }, [
+    setReadyToSubmit,
+    firstPrice,
+    opt1,
+    opt2,
+    opt3,
+    optFinal,
+    is2ndChecked,
+    secondPrice,
+    downTimeAfter,
+    userData,
+    bank,
+    accountNumber,
+  ]);
+};
+
+export default useReadyToSubmit;

--- a/src/hooks/common/useSubmitHandler.tsx
+++ b/src/hooks/common/useSubmitHandler.tsx
@@ -1,0 +1,127 @@
+import useToastConfig from "@/hooks/common/useToastConfig";
+import { useSelectedItemStore } from "@/store/store";
+import { ProfileData } from "@/types/profile";
+
+interface SubmitProps {
+  readyToSubmit: boolean;
+  firstPrice: string;
+  secondPrice: string;
+  downTimeAfter: string;
+  firstInputRef: React.MutableRefObject<null>;
+  secondPriceInputRef: React.MutableRefObject<null>;
+  secondTimeInputRef: React.MutableRefObject<null>;
+  is2ndChecked: boolean;
+  userData: ProfileData;
+  mutate: () => void;
+  opt1: boolean;
+  opt2: boolean;
+  opt3: boolean;
+  optFinal: boolean;
+}
+
+const useSubmitHandler = ({
+  readyToSubmit,
+  firstPrice,
+  secondPrice,
+  downTimeAfter,
+  firstInputRef,
+  secondPriceInputRef,
+  secondTimeInputRef,
+  is2ndChecked,
+  userData,
+  mutate,
+  opt1,
+  opt2,
+  opt3,
+  optFinal,
+}: SubmitProps) => {
+  const { handleToast } = useToastConfig();
+  const selectedItem = useSelectedItemStore((state) => state.selectedItem);
+
+  const submitHandler = () => {
+    if (!readyToSubmit) {
+      const firstPriceNum = Number(firstPrice.split(",").join(""));
+      const secondPriceNum = Number(secondPrice.split(",").join(""));
+      const downTimeAfterNum = Number(downTimeAfter);
+
+      if (!firstPriceNum) {
+        handleToast(true, [<>1차 가격을 설정해주세요</>]);
+        if (firstInputRef.current) {
+          (firstInputRef.current as HTMLInputElement).focus();
+          // + 스크롤 상단으로 올리기
+        }
+        // 1차 가격이 판매가보다 높을 때
+      } else if (firstPriceNum > selectedItem.purchasePrice) {
+        handleToast(true, [
+          <>판매가격이 구매가보다 높아요! 판매가격을 확인해주세요</>,
+        ]);
+
+        if (firstInputRef.current) {
+          (firstInputRef.current as HTMLInputElement).focus();
+          // + 스크롤 상단으로 올리기
+        }
+        // 2차 가격이 1차 가격보다 높을 때
+      } else if (secondPriceNum > firstPriceNum) {
+        handleToast(true, [<>2차가격은 1차 가격보다 낮게 설정해주세요</>]);
+
+        if (secondPriceInputRef.current) {
+          (secondPriceInputRef.current as HTMLInputElement).focus();
+          // + 스크롤 상단으로 올리기
+        }
+        // 2차가격 인하 시간을 3시간 이하로 설정했을 때
+      } else if (downTimeAfterNum && downTimeAfterNum < 3) {
+        handleToast(true, [
+          <>체크인 3시간 전까지만 2차 가격 설정이 가능해요</>,
+        ]);
+
+        if (secondTimeInputRef.current) {
+          (secondTimeInputRef.current as HTMLInputElement).focus();
+          // + 스크롤 상단으로 올리기
+        }
+        // 2차 가격만 입력하고 2차 기준시간은 입력 안 했을 때
+      } else if (is2ndChecked && secondPrice && !downTimeAfter) {
+        handleToast(true, [<>2차 가격으로 내릴 시간을 입력해주세요</>]);
+
+        if (secondTimeInputRef.current) {
+          (secondTimeInputRef.current as HTMLInputElement).focus();
+          // + 스크롤 상단으로 올리기
+        }
+        // 2차 기준시간만 입력하고 2차 가격은 입력 안 했을 때
+      } else if (is2ndChecked && !secondPrice && downTimeAfter) {
+        handleToast(true, [<>2차 가격을 입력해주세요</>]);
+
+        if (secondPriceInputRef.current) {
+          (secondPriceInputRef.current as HTMLInputElement).focus();
+          // + 스크롤 상단으로 올리기
+        }
+        // 2차 가격 설정을 체크해놓고 2차 가격과 시간 모두 입력 안 했을 때
+      } else if (is2ndChecked && !secondPrice && !downTimeAfter) {
+        handleToast(true, [<>2차 가격을 입력해주세요</>]);
+
+        if (secondTimeInputRef.current) {
+          (secondTimeInputRef.current as HTMLInputElement).focus();
+          // + 스크롤 상단으로 올리기
+        }
+      }
+      // 약관 동의를 다 안 했을 때
+      else if (!opt1 || !opt2 || !opt3 || !optFinal) {
+        handleToast(true, [<>판매 진행 약관에 동의해주세요</>]);
+
+        // 계좌를 입력 안 한 경우
+      } else if (!userData?.accountNumber) {
+        handleToast(true, [<>계좌를 입력해주세요</>]);
+      }
+
+      return;
+    }
+
+    const confirmToProceed = confirm("판매 게시물을 등록하시겠어요?");
+    if (confirmToProceed) {
+      mutate();
+    }
+  };
+
+  return [submitHandler];
+};
+
+export default useSubmitHandler;

--- a/src/pages/homePage/Home.style.ts
+++ b/src/pages/homePage/Home.style.ts
@@ -1,10 +1,10 @@
 import styled from "styled-components";
 
-export const Container = styled.section`
+export const Container = styled.section<{ weekLength: undefined | number }>`
   background-color: ${({ theme }) => theme.color.greyScale6};
 
   padding-top: 80px;
-  padding-bottom: 200px;
+  padding-bottom: ${({ weekLength }) => weekLength && "200px"};
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/src/pages/homePage/Home.style.ts
+++ b/src/pages/homePage/Home.style.ts
@@ -1,10 +1,10 @@
 import styled from "styled-components";
 
-export const Container = styled.section<{ weekLength: undefined | number }>`
+export const Container = styled.section<{ $weekLength: undefined | number }>`
   background-color: ${({ theme }) => theme.color.greyScale6};
 
   padding-top: 80px;
-  padding-bottom: ${({ weekLength }) => weekLength && "200px"};
+  padding-bottom: ${({ $weekLength }) => !$weekLength && "200px"};
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/src/pages/homePage/Home.tsx
+++ b/src/pages/homePage/Home.tsx
@@ -42,7 +42,6 @@ const Home = () => {
     (v, i) => [i, v],
   );
   const [weekendHotels] = useState(WeekendMapped);
-  console.log(weekendHotels, "weekendHotels");
 
   return (
     <S.Container>

--- a/src/pages/homePage/Home.tsx
+++ b/src/pages/homePage/Home.tsx
@@ -44,7 +44,7 @@ const Home = () => {
   const [weekendHotels] = useState(WeekendMapped);
 
   return (
-    <S.Container>
+    <S.Container $weekLength={weekendHotels?.length}>
       <MainHeader />
       <TitleSection />
       <NavToSearchSection />

--- a/src/pages/homePage/itemCarousel/ItemCarousel.tsx
+++ b/src/pages/homePage/itemCarousel/ItemCarousel.tsx
@@ -1,7 +1,6 @@
 import { useAnimateCarousel } from "@hooks/common/useAnimateCarousel";
 import { useCarouselSize } from "@hooks/common/useCarouselSize";
-
-import type { LocaleItem } from "@type/saleSection";
+import { type LocaleItem } from "@type/saleSection";
 import { useEffect } from "react";
 
 import * as S from "./ItemCarousel.style";

--- a/src/pages/transferWritingPricePage/accountSection/AccountSection.tsx
+++ b/src/pages/transferWritingPricePage/accountSection/AccountSection.tsx
@@ -1,5 +1,6 @@
-import type { ProfileData } from "@/types/profile";
 import * as S from "./AccountSection.style";
+
+import type { ProfileData } from "@/types/profile";
 
 interface AccountProps {
   bank: string | null;

--- a/src/pages/transferWritingPricePage/agreementSection/AgreementSection.tsx
+++ b/src/pages/transferWritingPricePage/agreementSection/AgreementSection.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from "react";
-import CheckBoxSection from "../checkBox/CheckBoxSection";
 
 import * as S from "./AgreementSection.style";
+import CheckBoxSection from "../checkBox/CheckBoxSection";
 
 interface AgreementProps {
   opt1: boolean;

--- a/src/pages/transferWritingPricePage/checkBox/CheckBoxSection.style.ts
+++ b/src/pages/transferWritingPricePage/checkBox/CheckBoxSection.style.ts
@@ -1,5 +1,6 @@
-import { ColorKeys, theme, TypoKeys } from "@/styles/theme";
 import styled from "styled-components";
+
+import { ColorKeys, theme, TypoKeys } from "@/styles/theme";
 
 export const CheckContainer = styled.section`
   display: flex;

--- a/src/pages/transferWritingPricePage/enterAccountInfo/EnterAccountInfo.tsx
+++ b/src/pages/transferWritingPricePage/enterAccountInfo/EnterAccountInfo.tsx
@@ -1,5 +1,3 @@
-import { BANK_LIST } from "@/constants/bank";
-import { PATH } from "@/constants/path";
 import usePreventLeave from "@hooks/common/usePreventLeave";
 import useToastConfig from "@hooks/common/useToastConfig";
 import { Nullable } from "@type/nullable";
@@ -8,6 +6,9 @@ import { useEffect, useRef, useState } from "react";
 import { useLocation } from "react-router-dom";
 
 import * as S from "./EnterAccountInfo.style";
+
+import { BANK_LIST } from "@/constants/bank";
+import { PATH } from "@/constants/path";
 
 const EnterAccountInfo = ({
   bank,

--- a/src/pages/transferWritingPricePage/firstPriceTag/FirstPriceTag.tsx
+++ b/src/pages/transferWritingPricePage/firstPriceTag/FirstPriceTag.tsx
@@ -1,9 +1,10 @@
-import priceFormat from "@/utils/priceFormat";
 import { useEffect } from "react";
+
+import * as S from "./FirstPriceTag.style";
 import CheckBoxSection from "../checkBox/CheckBoxSection";
 import InputSection from "../inputSection/InputSection";
 
-import * as S from "./FirstPriceTag.style";
+import priceFormat from "@/utils/priceFormat";
 
 interface PriceTagProps {
   checkRef: React.MutableRefObject<null>;

--- a/src/pages/transferWritingPricePage/inputSection/InputSection.tsx
+++ b/src/pages/transferWritingPricePage/inputSection/InputSection.tsx
@@ -1,7 +1,8 @@
-import priceFormat from "@/utils/priceFormat";
 import useToastConfig from "@hooks/common/useToastConfig";
 
 import * as S from "./InputSection.style";
+
+import priceFormat from "@/utils/priceFormat";
 
 interface InputProps {
   inputPosition: "left" | "center" | "right";

--- a/src/pages/transferWritingPricePage/paymentSection/PaymentSection.style.ts
+++ b/src/pages/transferWritingPricePage/paymentSection/PaymentSection.style.ts
@@ -1,7 +1,8 @@
-import { theme } from "@/styles/theme";
 import { motion } from "framer-motion";
 import { PiCaretDownBold } from "react-icons/pi";
 import styled from "styled-components";
+
+import { theme } from "@/styles/theme";
 
 export const Container = styled(motion.div)<{ $is2ndChecked: boolean }>`
   padding: 16px 20px;

--- a/src/pages/transferWritingPricePage/paymentSection/PaymentSection.tsx
+++ b/src/pages/transferWritingPricePage/paymentSection/PaymentSection.tsx
@@ -1,8 +1,9 @@
-import priceFormat from "@/utils/priceFormat";
 import { motion } from "framer-motion";
 import { useEffect, useState } from "react";
 
 import * as S from "./PaymentSection.style";
+
+import priceFormat from "@/utils/priceFormat";
 
 interface PaymentProps {
   price: string;


### PR DESCRIPTION
# 주의
현재 데이터가 없어서 정상 작동하는지는 확인 못해봤습니다. 
VSC에서 에러가 안 나는 상태여서 Push했을 뿐이고
실제 매물있는 아이디 하나 다시 얻어서 판매글 작성 페이지가 잘 되는지 체크해보고 머지해야될거 같습니다.

### Issue Number

close #319 

### ⛳️ Task

- [x] 화이팅하기
- [x] useChangePage(페이지 전환 시 체크박스 및 토글 상태 보존)
- [x] useReacdyToSubmit(각종 state의 변화에 따라 제출 버튼 활성화 될지 안 될지 여부)
- [x] useSubmitHandler(제출 버튼 눌렀을 때 최종적으로 정책 검사 후 mutate발생시키는 훅) 등 커스텀 훅으로 정리

### ✍️ Note
프로젝트 진행할 때 커스텀 훅 만드는 것에 익숙치 않아서 
거의 한 300줄의 예외처리 검사 로직을 늘어놓았는데
커스텀 훅으로 모두 정리했습니다. 휴우..ㅎ


```javascript
  useEffect(() => {
    setBank(userData?.bank ?? null);
    setAccountNumber(userData?.accountNumber ?? null);
  }, [userData]);

  // HOOKS
  // 작성 중 나가면 경고하는 훅
  usePreventLeave(true);

  // state변화에 따라 제출 버튼을 활성화/비활성화 하는 훅
  useReadyToSubmit({
    setReadyToSubmit,
    firstPrice,
    opt1,
    opt2,
    opt3,
    optFinal,
    bank,
    accountNumber,
    is2ndChecked,
    secondPrice,
    downTimeAfter,
    userData,
  });

  // 계좌 등록 페이지 <-> 판매글 작성 페이지 왔다갔다 할 때 체크박스나 토글 풀려있는거 복구하는 훅
  const { accountSetting, setAccountSetting } = useChangePage({
    is2ndChecked,
    firstCheckRef,
  });

  // 판매글 작성 POST 리액트 쿼리 훅
  const { mutate } = usePostTransferItems({
    firstPrice,
    secondPrice,
    downTimeAfter,
    is2ndChecked,
    opt1,
    opt2,
    opt3,
    optFinal,
    bank,
    accountNumber,
    userData,
  });

  // 정책들을 모두 검토하고 마지막에 usePostTransferItems API를 POST요청하는 훅
  const [submitHandler] = useSubmitHandler({
    readyToSubmit,
    firstPrice,
    secondPrice,
    downTimeAfter,
    firstInputRef,
    secondPriceInputRef,
    secondTimeInputRef,
    is2ndChecked,
    userData,
    mutate,
    opt1,
    opt2,
    opt3,
    optFinal,
  });
```

