### PR TITLE
[#339] UT용 다이렉트 로그인 처리

### DIFF
--- a/src/pages/signInPage/SignIn.tsx
+++ b/src/pages/signInPage/SignIn.tsx
@@ -1,6 +1,7 @@
 import { postLogin } from "@apis/fetchLogin";
 import { PATH } from "@constants/path";
 import useToastConfig from "@hooks/common/useToastConfig";
+import { useEffect } from "react";
 import { useForm } from "react-hook-form";
 import { Link, useNavigate, useSearchParams } from "react-router-dom";
 
@@ -18,6 +19,7 @@ const SignIn = () => {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const redirectUrl = searchParams.get("redirect");
+  const directUrl = searchParams.get("direct");
   const { handleToast } = useToastConfig();
 
   const {
@@ -30,6 +32,15 @@ const SignIn = () => {
       password: "",
     },
   });
+
+  useEffect(() => {
+    // TODO: UT용 다이렉트 로그인 처리
+    if (directUrl === "login") {
+      const email = "qwerty029369@gmail.com";
+      const password = "qwerty123@";
+      handleOnSubmit({ email, password });
+    }
+  }, [directUrl]);
 
   const handleOnSubmit = async (data: FormValues) => {
     const { email, password } = data;


### PR DESCRIPTION
### Issue Number

close #339 

### ⛳️ Task

- [x] UT용 다이렉트 로그인 처리
`/signin?direct=login`

### ✍️ Note

axios interceptor 이용하려고 했는데 axios 요청이 없으면 아무 의미가 없다는걸 깜빡했네용 ...ㅎ ^.ㅠ
Signin 페이지에서 searchparams로 다이렉트 url이 있으면 로그인처리되도록 구현했슴당..!
ut용 id, pwd는 스트링으로 박아뒀습니당
