### PR TITLE
Feat: Layout 컴포넌트 수정, Typo 컴포넌트 추가

### DIFF
--- a/src/components/layout/Layout.style.ts
+++ b/src/components/layout/Layout.style.ts
@@ -1,20 +1,16 @@
 import { styled } from "styled-components";
 
-export const Container = styled.div`
-  width: 100vw;
-  height: 100vh;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-`;
+import type { ColorKeys } from "@/styles/theme.ts";
 
-export const Wrapper = styled.div`
+export const Wrapper = styled.div.withConfig({
+  shouldForwardProp: (prop) => prop !== "bg",
+})<{ bg: ColorKeys }>`
+  width: 100%;
+  min-height: 100%;
   max-width: 768px;
   min-width: 360px;
-  width: 100%;
-  height: 100%;
   position: relative;
-  background-color: white;
   margin: 0 auto;
+
+  background-color: ${({ theme, bg }) => theme.color[bg]};
 `;

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -5,26 +5,33 @@ import * as S from "./Layout.style";
 import BottomNav from "./navBottom/NavBottom";
 import A2HS from "../A2HS/A2HS";
 
+import { ColorKeys } from "@/styles/theme.ts";
 import { isMobile } from "@/utils/isMobile";
 
 interface ChildrenProps {
   children: React.ReactNode;
-  isHeaderOn: boolean;
-  isBottomNavOn: boolean;
+  isHeaderOn?: boolean;
+  isBottomNavOn?: boolean;
+  bg?: ColorKeys;
 }
 
-const Layout = ({ children, isHeaderOn, isBottomNavOn }: ChildrenProps) => {
+const Layout = ({
+  children,
+  isHeaderOn = false,
+  isBottomNavOn = false,
+  bg = "white",
+}: ChildrenProps) => {
   const isMobileDevice = isMobile();
 
   return (
-    <S.Container>
-      <S.Wrapper>
-        {isHeaderOn && <Header />}
+    <>
+      {isHeaderOn && <Header />}
+      <S.Wrapper bg={bg}>
         {children}
         <A2HS />
-        {isBottomNavOn && <BottomNav isMobile={isMobileDevice} />}
       </S.Wrapper>
-    </S.Container>
+      {isBottomNavOn && <BottomNav isMobile={isMobileDevice} />}
+    </>
   );
 };
 

--- a/src/components/layout/header/HeaderTop.style.ts
+++ b/src/components/layout/header/HeaderTop.style.ts
@@ -4,6 +4,7 @@ import { styled } from "styled-components";
 export const HeaderContainer = styled.header`
   width: 100%;
   max-width: 768px;
+  min-width: 360px;
   height: 56px;
 
   display: flex;
@@ -14,6 +15,11 @@ export const HeaderContainer = styled.header`
   z-index: 10;
 
   background-color: white;
+
+  margin-left: auto;
+  margin-right: auto;
+  left: 0;
+  right: 0;
 `;
 
 export const HeaderCell = styled.div`

--- a/src/components/layout/header/HeaderTop.tsx
+++ b/src/components/layout/header/HeaderTop.tsx
@@ -1,9 +1,14 @@
-import { PATH } from "@/constants/path";
 import { useLocation, useNavigate } from "react-router-dom";
 
 import * as S from "./HeaderTop.style";
 
-const Header = () => {
+import { PATH } from "@/constants/path";
+
+interface HeaderProps {
+  text?: string;
+}
+
+const Header = ({ text }: HeaderProps) => {
   const navigate = useNavigate();
   const { pathname, search } = useLocation();
   const params = new URLSearchParams(search); // 쿼리스트링 분리
@@ -110,7 +115,7 @@ const Header = () => {
       <S.HeaderCell>
         {undo && <S.UndoIcon onClick={undoHandler} />}
       </S.HeaderCell>
-      <S.HeaderCell>{title}</S.HeaderCell>
+      <S.HeaderCell>{text ?? title}</S.HeaderCell>
       <S.HeaderCell>
         {settingIC && <S.AlarmIcon onClick={alarmHandler} />}
         {alarmIC && <S.SettingIcon onClick={settingHandler} />}

--- a/src/components/layout/navBottom/NavBottom.style.ts
+++ b/src/components/layout/navBottom/NavBottom.style.ts
@@ -1,4 +1,3 @@
-import NavIconHome from "@/assets/icons/NavHome";
 import {
   PiListMagnifyingGlassFill,
   PiNewspaperClippingFill,
@@ -7,18 +6,26 @@ import {
 import { NavLink } from "react-router-dom";
 import styled from "styled-components";
 
+import NavIconHome from "@/assets/icons/NavHome";
+
 export const BottomNavContainer = styled.section<{ $isMobile: boolean }>`
   display: flex;
   position: fixed;
   bottom: 0;
   width: 100%;
   max-width: 768px;
+  min-width: 360px;
   z-index: 1;
   height: ${({ $isMobile }) => ($isMobile ? "78px" : "60px")};
   justify-content: center;
   align-items: flex-start;
   background-color: white;
   box-shadow: 0 0 10px 0 rgba(5, 44, 82, 0.1);
+
+  margin-left: auto;
+  margin-right: auto;
+  left: 0;
+  right: 0;
 `;
 
 export const BottomNavWrapper = styled.div`

--- a/src/components/ui/polymorphic.d.ts
+++ b/src/components/ui/polymorphic.d.ts
@@ -1,0 +1,21 @@
+import React from "react";
+
+type PolymorphicRef<C extends React.ElementType> =
+  ComponentPropsWithRef<C>["ref"];
+
+type AsProp<C extends React.ElementType> = {
+  as?: C;
+};
+
+type PropsToOmit<C extends React.ElementType, P> = keyof (AsProp<C> & P);
+
+export type PolymorphicComponentProp<
+  C extends React.ElementType,
+  Props = object,
+> = React.PropsWithChildren<Props & AsProp<C>> &
+  Omit<React.ComponentPropsWithoutRef<C>, PropsToOmit<C, Props>>;
+
+export type PolymorphicComponentPropsWithRef<
+  C extends React.ElementType,
+  Props = object,
+> = PolymorphicComponentProp<C, Props> & { ref?: PolymorphicRef<C> };

--- a/src/components/ui/typo/index.ts
+++ b/src/components/ui/typo/index.ts
@@ -1,0 +1,1 @@
+export * from "./typo.tsx";

--- a/src/components/ui/typo/typo.styles.ts
+++ b/src/components/ui/typo/typo.styles.ts
@@ -1,0 +1,43 @@
+import styled, { CSSProperties, css } from "styled-components";
+
+import type { ColorKeys, TypoKeys } from "@/styles/theme.ts";
+
+export interface IStyledTextProps {
+  color?: ColorKeys;
+  typo: TypoKeys;
+  isEllipsis?: boolean;
+  textAlign?: CSSProperties["textAlign"];
+}
+
+export type StyledEmEmProps = {
+  color?: ColorKeys;
+};
+
+export const StyledTypo = styled.span.withConfig({
+  shouldForwardProp: (prop) =>
+    !["color", "typo", "isEllipsis", "textAlign"].includes(prop),
+})<IStyledTextProps>`
+  color: ${({ color, theme }) => (color && theme.color[color]) || "inherit"};
+
+  ${({ theme, typo }) => theme.typo[typo]};
+
+  text-align: ${({ textAlign }) => textAlign || ""};
+
+  ${({ isEllipsis }) =>
+    isEllipsis &&
+    css`
+      overflow: hidden;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+    `};
+
+  &.pre {
+    white-space: pre-wrap;
+  }
+`;
+
+export const StyledEm = styled.em.withConfig({
+  shouldForwardProp: (prop) => !["color"].includes(prop),
+})<StyledEmEmProps>`
+  color: ${({ theme, color }) => (color && theme.color[color]) || "inherit"};
+`;

--- a/src/components/ui/typo/typo.tsx
+++ b/src/components/ui/typo/typo.tsx
@@ -1,0 +1,44 @@
+import { forwardRef, Children, isValidElement, ElementType } from "react";
+
+import {
+  type IStyledTextProps,
+  type StyledEmEmProps,
+  StyledTypo,
+  StyledEm,
+} from "./typo.styles.ts";
+
+import type {
+  PolymorphicComponentPropsWithRef,
+  PolymorphicRef,
+} from "../polymorphic";
+
+export type TextProps<C extends ElementType = "span"> =
+  PolymorphicComponentPropsWithRef<C, IStyledTextProps & StyledEmEmProps>;
+
+export const Typo = forwardRef(function Typo<C extends ElementType = "span">(
+  props: TextProps<C>,
+  ref?: PolymorphicRef<C>,
+) {
+  const { as, color, typo, isEllipsis, children, ...rest } = props;
+
+  const styledChildren = Children.map(children, (child) => {
+    if (isValidElement(child) && child.type === "em") {
+      const color = child.props.color;
+      return <StyledEm color={color}>{child.props.children}</StyledEm>;
+    }
+    return child;
+  });
+
+  return (
+    <StyledTypo
+      ref={ref}
+      as={as}
+      color={color}
+      typo={typo}
+      isEllipsis={isEllipsis}
+      {...rest}
+    >
+      {styledChildren}
+    </StyledTypo>
+  );
+});

--- a/src/components/ui/typo/typo.tsx
+++ b/src/components/ui/typo/typo.tsx
@@ -10,7 +10,7 @@ import {
 import type {
   PolymorphicComponentPropsWithRef,
   PolymorphicRef,
-} from "../polymorphic";
+} from "@components/ui/polymorphic";
 
 export type TextProps<C extends ElementType = "span"> =
   PolymorphicComponentPropsWithRef<C, IStyledTextProps & StyledEmEmProps>;
@@ -19,7 +19,14 @@ export const Typo = forwardRef(function Typo<C extends ElementType = "span">(
   props: TextProps<C>,
   ref?: PolymorphicRef<C>,
 ) {
-  const { as, color, typo, isEllipsis, children, ...rest } = props;
+  const {
+    as,
+    color = "black",
+    typo = "body1",
+    isEllipsis = false,
+    children,
+    ...rest
+  } = props;
 
   const styledChildren = Children.map(children, (child) => {
     if (isValidElement(child) && child.type === "em") {

--- a/src/styles/globalStyle.ts
+++ b/src/styles/globalStyle.ts
@@ -28,4 +28,9 @@ export const GlobalStyle = createGlobalStyle`
     overflow-y: auto;
     overflow-x: hidden;
   }
+
+  #root {
+    width: 100vw;
+    height: 100vh;
+  }
 `;


### PR DESCRIPTION
### Issue Number

close 

### ⛳️ Task

- [x] Layout 컴포넌트 변경
- [x] Typo 컴포넌트 추가

### ✍️ Note

### 1. Layout 컴포넌트 변경
- bg 프로퍼티 추가 → 배경색 지정 가능
- isHeaderOn, isBottomNavOn props 타입 옵셔널로 변경, default = false
- Header 컴포넌트 text 프로퍼티 추가 → 헤더 타이틀을 text 프로퍼티 통해서 전달 가능

Layout을 좀 더 유연하게 수정할 수 있게끔 변경했습니다.

### 2. Typo 컴포넌트 추가
간단한 타이포그래피용 컴포넌트를 추가했습니다.

```ts
<Typo as="p" typo="body1" color="black">텍스트 입력</Typo>
```
**Props**
- `as?: ElementType` default `span`
- `typo: TypoKeys`
- `color?: ColorKeys` default black
- `isEllipsis: boolean` default `false`
- `textAlign?: CSSProperties["textAlign"]`



### 📎 Reference
