### PR TITLE
HotFix: 상세페이지 로그인 상태 여부에 따른 클라이언트 변경

### DIFF
--- a/src/apis/fetchRoom.ts
+++ b/src/apis/fetchRoom.ts
@@ -1,25 +1,22 @@
 import axios from "axios";
 
+import { axiosInstance } from "./axiosInstance";
+
 import type { ResponseData } from "@/types/responseType";
 import type { RoomData } from "@/types/room";
 
-import { ACCESS_TOKEN, BASE_URL, END_POINTS } from "@/constants/api";
+import { BASE_URL, END_POINTS } from "@/constants/api";
 
 export const getRoom = async (
   productId: string,
   isLoggedIn: boolean,
 ): Promise<RoomData> => {
-  const headers: Record<string, string> = {};
+  const client = isLoggedIn ? axiosInstance : axios;
+  const url = isLoggedIn
+    ? END_POINTS.ROOM(productId)
+    : `${BASE_URL}${END_POINTS.ROOM(productId)}`;
 
-  if (isLoggedIn) {
-    const accessToken = localStorage.getItem(ACCESS_TOKEN);
-    headers["Authorization"] = `${accessToken}`;
-  }
-
-  const { data } = await axios.get<ResponseData<RoomData>>(
-    `${BASE_URL}${END_POINTS.ROOM(productId)}`,
-    { headers },
-  );
+  const { data } = await client.get<ResponseData<RoomData>>(url);
 
   return data.data;
 };


### PR DESCRIPTION
### Issue Number

close

### ⛳️ Task

- 상세페이지에서 로그인 O →`axiosInstance`로, 로그인 X → `axios` 객체를 사용하도록 로직을 추가했씁니당

### ✍️ Note

### 📸 Screenshot

### 📎 Reference
